### PR TITLE
Fixing .net 4 acceptance test issues

### DIFF
--- a/src/ZendeskApi.Acceptance/Tickets.feature
+++ b/src/ZendeskApi.Acceptance/Tickets.feature
@@ -34,7 +34,7 @@ Scenario: When I call Post I am able to add a ticket with a custom field
 	When I set the first ticket custom fields with the value of 'true'
 	And I call get by id on the ZendeskApiClient
 	Then I get a task from Zendesk with the subject 'I've swallowed my mouse cable' and description 'It's a bit of a problem' and type 'task'
-	And the ticket has the custom field set with the value 'true'
+	And the ticket has the custom field set with the value 'True'
 
 Scenario: When I call Put I am able to update a ticket
 	Given a ticket in Zendesk with the subject 'I've swallowed my mouse cable' and description 'It's a bit of a problem'

--- a/src/ZendeskApi.Acceptance/Tickets.feature.cs
+++ b/src/ZendeskApi.Acceptance/Tickets.feature.cs
@@ -177,7 +177,7 @@ this.ScenarioSetup(scenarioInfo);
  testRunner.Then("I get a task from Zendesk with the subject \'I\'ve swallowed my mouse cable\' and de" +
                     "scription \'It\'s a bit of a problem\' and type \'task\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 37
- testRunner.And("the ticket has the custom field set with the value \'true\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the ticket has the custom field set with the value \'True\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/ZendeskApi.Acceptance/ZendeskApi.Acceptance.csproj
+++ b/src/ZendeskApi.Acceptance/ZendeskApi.Acceptance.csproj
@@ -32,13 +32,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CDA8A5A6-461A-48C5-865F-812CF7275407}</ProjectGuid>
-    <ContractsAssemblyName>ZendeskApi.Contracts</ContractsAssemblyName>
     <RootNamespace>ZendeskApi.Acceptance</RootNamespace>
     <AssemblyName>ZendeskApi.Acceptance</AssemblyName>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <!--If configuration is not provided, default to Debug build-->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <Choose>
     <When Condition="$(Configuration.Contains('Debug'))">
@@ -118,7 +117,7 @@
     </Compile>
     <Compile Include="UserIdentityResourceSteps.cs" />
   </ItemGroup>
-  <ItemGroup Condition="$(Configuration.Contains('40'))">
+  <ItemGroup>
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
Fixing .net 4 acceptance test issues - app settings is required for all framework versions as it may contain connection strings.

Also updating the tickets test. The acceptance tests use just eat's sandbox and someone has set the custom field used to a check box so the value used in the test has to be true/false.