### PR TITLE
Initialise CustomFields list in Request class

### DIFF
--- a/src/ZendeskApi.Contracts/Models/Request.cs
+++ b/src/ZendeskApi.Contracts/Models/Request.cs
@@ -11,6 +11,11 @@ namespace ZendeskApi.Contracts.Models
     [DataContract]
     public class Request : IZendeskEntity
     {
+        public Request()
+        {
+            CustomFields = new List<CustomField>();
+        }
+        
         [DataMember(EmitDefaultValue = false)]
         public long? Id { get; set; }
 


### PR DESCRIPTION
Custom fields cannot be added to Request objects since the `CustomFields` member is both private and uninitialised.  Added a constructor to Request.cs to initialise the list.