### PR TITLE
Add Hold Ticket Status

### DIFF
--- a/src/ZendeskApi.Contracts/Models/TicketStatus.cs
+++ b/src/ZendeskApi.Contracts/Models/TicketStatus.cs
@@ -14,6 +14,8 @@ namespace ZendeskApi.Contracts.Models
         [EnumMember(Value = "pending")]
         Pending,
         [EnumMember(Value = "solved")]
-        Solved
+        Solved,
+        [EnumMember(Value = "hold")]
+        Hold
     }
 }


### PR DESCRIPTION
Add Hold Ticket Status to Models. Allows ZenDesk accounts with Hold
ticket status enabled to use the API.