### PR TITLE
support for setting tags and custom fields

### DIFF
--- a/src/ZendeskApi.Contracts/Models/Request.cs
+++ b/src/ZendeskApi.Contracts/Models/Request.cs
@@ -82,6 +82,6 @@ namespace ZendeskApi.Contracts.Models
         public Via Via { get; set; }
 
         [DataMember(Name = "custom_fields")]
-        public List<CustomField> CustomFields { get; private set; }
+        public List<CustomField> CustomFields { get; set; }
     }
 }

--- a/src/ZendeskApi.Contracts/Models/Ticket.cs
+++ b/src/ZendeskApi.Contracts/Models/Ticket.cs
@@ -93,7 +93,7 @@ namespace ZendeskApi.Contracts.Models
         public bool has_incidents { get; set; }
 
         [DataMember(Name = "tags", EmitDefaultValue = false)]
-        public List<string> tags { get; set; }
+        public List<string> Tags { get; set; }
 
         [IgnoreDataMember]
         public List<object> sharing_agreement_ids { get; set; }

--- a/src/ZendeskApi.Contracts/Models/Ticket.cs
+++ b/src/ZendeskApi.Contracts/Models/Ticket.cs
@@ -71,7 +71,7 @@ namespace ZendeskApi.Contracts.Models
         public Via Via { get; set; }
 
         [DataMember(Name = "custom_fields")]
-        public List<CustomField> CustomFields { get; private set; }
+        public List<CustomField> CustomFields { get; set; }
 
         [DataMember(Name = "satisfaction_rating")]
         public object SatisfactionRating { get; set; }
@@ -92,7 +92,7 @@ namespace ZendeskApi.Contracts.Models
         [IgnoreDataMember]
         public bool has_incidents { get; set; }
 
-        [IgnoreDataMember]
+        [DataMember(Name = "tags", EmitDefaultValue = false)]
         public List<string> tags { get; set; }
 
         [IgnoreDataMember]


### PR DESCRIPTION
Great work on the Zendesk API client! I appreciate the work you've put into it!

I saw the 2 issues submitted by @bmnielsen about tags and custom fields. I'm experiencing the same issues, so I took a quick try at a fix. The change is simple and seems to work well. 

Applying the [DataMember] attribute for tags was all that was required to set tags. And removing the private keyword from the setter on CustomFields allowed me to specify tags at ticket creation. Was there a specific reason you were using a private set? 

Let me know what you think.  