### PR TITLE
Added DataMember names for priority and external_id

### DIFF
--- a/src/ZendeskApi.Contracts/Models/Ticket.cs
+++ b/src/ZendeskApi.Contracts/Models/Ticket.cs
@@ -55,7 +55,7 @@ namespace ZendeskApi.Contracts.Models
         [DataMember(EmitDefaultValue = false)]
         public Uri Url { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(Name = "priority", EmitDefaultValue = false)]
         public string Priority { get; set; }
 
         [DataMember(Name = "recipient", EmitDefaultValue = false)]
@@ -77,7 +77,7 @@ namespace ZendeskApi.Contracts.Models
         public object SatisfactionRating { get; set; }
 
         // ReSharper disable InconsistentNaming
-        [IgnoreDataMember]
+        [DataMember(Name = "external_id", EmitDefaultValue = false)]
         public long? External_Id { get; set; }
 
         [IgnoreDataMember]


### PR DESCRIPTION
I was using this API and came across a few issues that I was able to fix internally. I am not sure if ExternalId purposely had [IgnoreDataMember] set but I was unable to access it when writing or reading a ticket, so I added the DataMember name. I also needed to access priority, so I added the name there as well.