### PR TITLE
Additional requester property for Ticket API

### DIFF
--- a/src/ZendeskApi.Contracts/Models/Ticket.cs
+++ b/src/ZendeskApi.Contracts/Models/Ticket.cs
@@ -106,6 +106,9 @@ namespace ZendeskApi.Contracts.Models
 
         [IgnoreDataMember]
         public List<long> followup_ids { get; set; }
+
+        [DataMember(Name = "requester")]
+        public TicketRequester Requester { get; set; }
 // ReSharper restore InconsistentNaming
     }
 }

--- a/src/ZendeskApi.Contracts/Models/TicketRequester.cs
+++ b/src/ZendeskApi.Contracts/Models/TicketRequester.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace ZendeskApi.Contracts.Models
+{
+    // partially documented under 
+    // https://developer.zendesk.com/rest_api/docs/core/tickets#creating-a-ticket-with-a-new-requester
+    [Description("Requester")]
+    [DataContract]
+    public class TicketRequester
+    {
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "email")]
+        public string Email { get; set; }
+
+        [DataMember(Name = "locale_id")]
+        public int? Locale { get; set; }
+    }
+}

--- a/src/ZendeskApi.Contracts/ZendeskApi.Contracts.csproj
+++ b/src/ZendeskApi.Contracts/ZendeskApi.Contracts.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Models\TicketComment.cs" />
     <Compile Include="Models\TicketEventType.cs" />
     <Compile Include="Models\SatisfactionRatingScore.cs" />
+    <Compile Include="Models\TicketRequester.cs" />
     <Compile Include="Models\Upload.cs" />
     <Compile Include="Models\User.cs" />
     <Compile Include="Models\Via.cs" />


### PR DESCRIPTION
It's weird that they don't define this property within the Ticket object itself, only partially noted in docs here.

https://developer.zendesk.com/rest_api/docs/core/tickets#creating-a-ticket-with-a-new-requester

Useful for creating a ticket with new (or old) requester.