### PR TITLE
External_Id field, incorrect type long? converted to string

### DIFF
--- a/src/ZendeskApi.Contracts/Models/Organization.cs
+++ b/src/ZendeskApi.Contracts/Models/Organization.cs
@@ -49,8 +49,8 @@ namespace ZendeskApi.Contracts.Models
         [IgnoreDataMember]
         public long group_id { get; set; }
 
-        [IgnoreDataMember]
-        public long external_id { get; set; }
+        [DataMember(Name = "external_id", EmitDefaultValue = false)]
+        public string external_id { get; set; }
 
         [IgnoreDataMember]
         public object domain_names { get; set; }

--- a/src/ZendeskApi.Contracts/Models/Organization.cs
+++ b/src/ZendeskApi.Contracts/Models/Organization.cs
@@ -32,6 +32,9 @@ namespace ZendeskApi.Contracts.Models
 
         [DataMember(Name = "organization_fields", EmitDefaultValue = true)]
         public Dictionary<object, object> CustomFields { get; set; }
+        
+        [DataMember(Name = "external_id", EmitDefaultValue = false)]
+        public string external_id { get; set; }
 
 // ReSharper disable InconsistentNaming       
         [IgnoreDataMember]
@@ -48,9 +51,6 @@ namespace ZendeskApi.Contracts.Models
 
         [IgnoreDataMember]
         public long group_id { get; set; }
-
-        [DataMember(Name = "external_id", EmitDefaultValue = false)]
-        public string external_id { get; set; }
 
         [IgnoreDataMember]
         public object domain_names { get; set; }

--- a/src/ZendeskApi.Contracts/Models/Ticket.cs
+++ b/src/ZendeskApi.Contracts/Models/Ticket.cs
@@ -78,7 +78,7 @@ namespace ZendeskApi.Contracts.Models
 
         // ReSharper disable InconsistentNaming
         [DataMember(Name = "external_id", EmitDefaultValue = false)]
-        public long? External_Id { get; set; }
+        public string External_Id { get; set; }
 
         [IgnoreDataMember]
         public List<long> collaborator_ids { get; set; }


### PR DESCRIPTION
Hi,

this is my first pull request, i'm newbie in GItHub and I hope that i've done things correctly.

I found this problem that causes newtonsoft to throw a serialization exception in case External_Id is setted to a non long value (a string).

As Zendesk's api says [zendesk] (https://developer.zendesk.com/rest_api/docs/core/tickets#content) external id is a string not a long. 

I've just modified it, the types of the properties.