### PR TITLE
Custom fields are long, not int

### DIFF
--- a/src/ZendeskApi.Acceptance/TicketSteps.cs
+++ b/src/ZendeskApi.Acceptance/TicketSteps.cs
@@ -19,7 +19,7 @@ namespace ZendeskApi.Acceptance
         private readonly List<Ticket> _savedMultipleTicket = new List<Ticket>();
         private readonly List<Ticket> _multipleTicketResponse = new List<Ticket>();
 
-        private int _customFieldId;
+        private long _customFieldId;
 
         private Ticket _savedSingleTicket;
         private Ticket _singleTicketResponse;

--- a/src/ZendeskApi.Contracts/Models/CustomField.cs
+++ b/src/ZendeskApi.Contracts/Models/CustomField.cs
@@ -8,7 +8,7 @@ namespace ZendeskApi.Contracts.Models
     public class CustomField
     {
         [DataMember(Name = "id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [DataMember(Name = "value")]
         public string Value { get; set; }


### PR DESCRIPTION
Fixes #47. Presents custom field IDs as `long`.