### PR TITLE
Sync not using async anymore (that was a bad idea)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Zendesk Api Client #
 ====================
 
+
+
 A .net Zendesk Api Client NuGet package for use with the ZendeskApi v2
+
+#Breaking Changes#
+* 2.x.x - .Net Framework version 4.0 is no longer supported
 
 ##Creating a client:##
 

--- a/ZendeskApiClient.sln
+++ b/ZendeskApiClient.sln
@@ -1,9 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40121.0
-VisualStudioVersion = 12.0.31101.0
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AcceptanceTests", "AcceptanceTests", "{E1E8E158-EFFE-40B4-96F8-8C2083ED1C88}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZendeskApi.Acceptance", "src\ZendeskApi.Acceptance\ZendeskApi.Acceptance.csproj", "{CDA8A5A6-461A-48C5-865F-812CF7275407}"

--- a/ZendeskApiClient.sln
+++ b/ZendeskApiClient.sln
@@ -2,6 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AcceptanceTests", "AcceptanceTests", "{E1E8E158-EFFE-40B4-96F8-8C2083ED1C88}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZendeskApi.Acceptance", "src\ZendeskApi.Acceptance\ZendeskApi.Acceptance.csproj", "{CDA8A5A6-461A-48C5-865F-812CF7275407}"
@@ -17,51 +18,29 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug40|Any CPU = Debug40|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Release40|Any CPU = Release40|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Debug40|Any CPU.ActiveCfg = Debug40|Any CPU
-		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Debug40|Any CPU.Build.0 = Debug40|Any CPU
 		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Release40|Any CPU.ActiveCfg = Release40|Any CPU
-		{CDA8A5A6-461A-48C5-865F-812CF7275407}.Release40|Any CPU.Build.0 = Release40|Any CPU
 		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Debug40|Any CPU.ActiveCfg = Debug40|Any CPU
-		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Debug40|Any CPU.Build.0 = Debug40|Any CPU
 		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Release40|Any CPU.ActiveCfg = Release40|Any CPU
-		{BEA9E134-91FF-40D6-9B5D-BD57006DBBC6}.Release40|Any CPU.Build.0 = Release40|Any CPU
 		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Debug40|Any CPU.ActiveCfg = Debug40|Any CPU
-		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Debug40|Any CPU.Build.0 = Debug40|Any CPU
 		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Release40|Any CPU.ActiveCfg = Release40|Any CPU
-		{182231A6-213B-4F9B-851D-ED5B7E6DA53D}.Release40|Any CPU.Build.0 = Release40|Any CPU
 		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Debug40|Any CPU.ActiveCfg = Debug40|Any CPU
-		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Debug40|Any CPU.Build.0 = Debug40|Any CPU
 		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Release40|Any CPU.ActiveCfg = Release40|Any CPU
-		{C53ACF17-3DCD-4A21-B22A-1A8CA47FD85B}.Release40|Any CPU.Build.0 = Release40|Any CPU
 		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Debug40|Any CPU.ActiveCfg = Debug40|Any CPU
-		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Debug40|Any CPU.Build.0 = Debug40|Any CPU
 		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Release|Any CPU.Build.0 = Release|Any CPU
-		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Release40|Any CPU.ActiveCfg = Release40|Any CPU
-		{710E1917-AC01-4877-9683-AF47A7DBDF84}.Release40|Any CPU.Build.0 = Release40|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ZendeskApi.Acceptance/OrganizationSteps.cs
+++ b/src/ZendeskApi.Acceptance/OrganizationSteps.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Web;
+using System.Threading.Tasks;
 using ZendeskApi.Client;
 using ZendeskApi.Contracts.Models;
 using ZendeskApi.Contracts.Requests;

--- a/src/ZendeskApi.Acceptance/OrganizationSteps.cs
+++ b/src/ZendeskApi.Acceptance/OrganizationSteps.cs
@@ -97,8 +97,7 @@ namespace ZendeskApi.Acceptance
         [Then(@"the Organization is no longer in zendesk")]
         public void ThenTheOrganizationIsNoLongerInZendesk()
         {
-            Assert.That(() => _client.Organizations.Get((long)_savedSingleOrganization.Id),
-                Throws.InnerException.TypeOf<HttpException>().And.InnerException.Message.EqualTo("{\"error\":\"RecordNotFound\",\"description\":\"Not found\"}"));
+            Assert.Throws<HttpException>(() => _client.Organizations.Get((long)_savedSingleOrganization.Id), "Organization not in Zendesk");
         }
 
         [AfterScenario]

--- a/src/ZendeskApi.Acceptance/RequestSteps.cs
+++ b/src/ZendeskApi.Acceptance/RequestSteps.cs
@@ -48,8 +48,8 @@ namespace ZendeskApi.Acceptance
         [Then(@"I get a request from Zendesk with the subject '(.*)' and description '(.*)'")]
         public void ThenIGetARequestFromZendeskWithTheSubjectAndDescriptionTWorkInTheseConditions(string subject, string description)
         {
-            Assert.That(_singleRequestResponse.Subject, Is.EqualTo(subject));
-            Assert.That(_singleRequestResponse.Description, Is.EqualTo(description));
+            StringAssert.AreEqualIgnoringCase(subject, _singleRequestResponse.Subject);
+            StringAssert.StartsWith(description, _singleRequestResponse.Description);
             Assert.That(_singleRequestResponse.Created, Is.GreaterThan(DateTime.UtcNow.AddMinutes(-2)));
         }
 

--- a/src/ZendeskApi.Acceptance/TicketSteps.cs
+++ b/src/ZendeskApi.Acceptance/TicketSteps.cs
@@ -152,8 +152,7 @@ namespace ZendeskApi.Acceptance
         [Then(@"the ticket is no longer in zendesk")]
         public void ThenTheTicketIsNoLongerInZendesk()
         {
-            Assert.That(() => _client.Tickets.Get((long)_savedSingleTicket.Id),
-                Throws.InnerException.TypeOf<HttpException>().And.InnerException.Message.EqualTo("{\"error\":\"RecordNotFound\",\"description\":\"Not found\"}"));
+            Assert.Throws<HttpException>(() => _client.Tickets.Get((long) _savedSingleTicket.Id), "Tickets not in Zendesk");
         }
 
         [AfterScenario]

--- a/src/ZendeskApi.Acceptance/ZendeskApi.Acceptance.csproj
+++ b/src/ZendeskApi.Acceptance/ZendeskApi.Acceptance.csproj
@@ -38,6 +38,8 @@
     <!--If configuration is not provided, default to Debug build-->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <OutputPath>bin\$(Configuration)\</OutputPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Choose>
     <When Condition="$(Configuration.Contains('Debug'))">
@@ -191,5 +193,12 @@
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="bin" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
 </Project>

--- a/src/ZendeskApi.Acceptance/packages.config
+++ b/src/ZendeskApi.Acceptance/packages.config
@@ -6,4 +6,5 @@
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
   <package id="SpecFlow" version="1.9.0" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Acceptance/packages.config
+++ b/src/ZendeskApi.Acceptance/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
   <package id="SpecFlow" version="1.9.0" />

--- a/src/ZendeskApi.Acceptance/packages.config
+++ b/src/ZendeskApi.Acceptance/packages.config
@@ -6,5 +6,4 @@
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
   <package id="SpecFlow" version="1.9.0" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Client.Tests/Resources/AssignableGroupResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/AssignableGroupResourceFixture.cs
@@ -30,5 +30,20 @@ namespace ZendeskApi.Client.Tests.Resources
             _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("/assignable")), ""));
         }
 
+
+        [Test]
+        public async void GetAllAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://search"));
+            var groupResource = new AssignableGroupResource(_client.Object);
+
+            // When
+            await groupResource.GetAllAsync();
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("/assignable")), ""));
+        }
+
     }
 }

--- a/src/ZendeskApi.Client.Tests/Resources/GroupResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/GroupResourceFixture.cs
@@ -20,6 +20,20 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://zendesk"));
+            var groupResource = new GroupsResource(_client.Object);
+
+            // When
+            await groupResource.GetAsync(321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("/groups/321")), ""));
+        }
+
+        [Test]
         public void Get_Called_CallsBuildUriWithFieldId()
         {
             // Given
@@ -35,11 +49,27 @@ namespace ZendeskApi.Client.Tests.Resources
 
 
         [Test]
-        public void Get_Called_ReturnsResponse()
+        public async void GetAsync_Called_ReturnsResponse()
         {
             // Given
             var response = new GroupResponse { Item = new Group { Id = 1 }};
             _client.Setup(b => b.GetAsync<GroupResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://zendesk"));
+            var groupResource = new GroupsResource(_client.Object);
+
+            // When
+            var result = await groupResource.GetAsync(321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public void Get_Called_ReturnsResponse()
+        {
+            // Given
+            var response = new GroupResponse { Item = new Group { Id = 1 }};
+            _client.Setup(b => b.Get<GroupResponse>(It.IsAny<Uri>())).Returns(response);
             _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://zendesk"));
             var groupResource = new GroupsResource(_client.Object);
 

--- a/src/ZendeskApi.Client.Tests/Resources/OrganizationMembershipResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/OrganizationMembershipResourceFixture.cs
@@ -36,7 +36,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAllByOrganizationAsync_Called_CallsBuildUriWithFieldIdAndType()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("http://search"));
+            var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
+
+            // When
+            await organizationMembershipResource.GetAllByOrganizationAsync(4321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(st => st.Contains("4321") && st.Contains("/organizations/")), ""));
+        }
+
+        [Test]
         public void GetAllByOrganization_Called_ReturnsOrganizationMembershipResponse()
+        {
+            // Given
+            var response = new OrganizationMembershipListResponse { Results = new List<OrganizationMembership> { new OrganizationMembership { Id = 1 } } };
+            _client.Setup(b => b.Get<OrganizationMembershipListResponse>(It.IsAny<Uri>())).Returns(response);
+            var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
+
+            // When
+            var result = organizationMembershipResource.GetAllByOrganization(4321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAllByOrganizationAsync_Called_ReturnsOrganizationMembershipResponse()
         {
             // Given
             var response = new OrganizationMembershipListResponse { Results = new List<OrganizationMembership> { new OrganizationMembership { Id = 1 } } };
@@ -44,7 +73,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
 
             // When
-            var result = organizationMembershipResource.GetAllByOrganization(4321);
+            var result = await organizationMembershipResource.GetAllByOrganizationAsync(4321);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -65,11 +94,25 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAllByUserAsync_Called_CallsBuildUriWithFieldIdAndType()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("http://search"));
+            var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
+
+            // When
+            await organizationMembershipResource.GetAllByUserAsync(4321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(st => st.Contains("4321") && st.Contains("/users/")), ""));
+        }
+
+        [Test]
         public void GetAllByUser_Called_ReturnsOrganizationMembershipResponse()
         {
             // Given
             var response = new OrganizationMembershipListResponse { Results = new List<OrganizationMembership> { new OrganizationMembership { Id = 1 } } };
-            _client.Setup(b => b.GetAsync<OrganizationMembershipListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            _client.Setup(b => b.Get<OrganizationMembershipListResponse>(It.IsAny<Uri>())).Returns(response);
             var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
 
             // When
@@ -80,7 +123,22 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
-        public void GetAll_Called_CallsBuildUriWithFieldId()
+        public async void GetAllByUserAsync_Called_ReturnsOrganizationMembershipResponse()
+        {
+            // Given
+            var response = new OrganizationMembershipListResponse { Results = new List<OrganizationMembership> { new OrganizationMembership { Id = 1 } } };
+            _client.Setup(b => b.GetAsync<OrganizationMembershipListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
+
+            // When
+            var result = await organizationMembershipResource.GetAllByUserAsync(4321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public void GetAllAsync_Called_CallsBuildUriWithFieldId()
         {
             // Given
             _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("http://search"));
@@ -98,7 +156,7 @@ namespace ZendeskApi.Client.Tests.Resources
         {
             // Given
             var response = new OrganizationMembershipListResponse { Results = new List<OrganizationMembership> { new OrganizationMembership { Id = 1 } } };
-            _client.Setup(b => b.GetAsync<OrganizationMembershipListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            _client.Setup(b => b.Get<OrganizationMembershipListResponse>(It.IsAny<Uri>())).Returns(response);
             var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
 
             // When
@@ -123,7 +181,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PostAsync_Called_BuildsUriWithFieldUserId()
+        {
+            // Given
+            var request = new OrganizationMembershipRequest { Item = new OrganizationMembership { UserId = 1234 } };
+            var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
+
+            // When
+            await organizationMembershipResource.PostAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.Is<string>(s => s.Contains("1234")), ""));
+        }
+
+        [Test]
         public void Post_CalledWithId_ReturnsReponseWithId()
+        {
+            // Given
+            var response = new OrganizationMembershipResponse { Item = new OrganizationMembership { Id = 123 } };
+            var request = new OrganizationMembershipRequest { Item = new OrganizationMembership { Id = 123 } };
+            _client.Setup(b => b.Post<OrganizationMembershipResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
+
+            // When
+            var result = organizationMembershipResource.Post(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PostAsync_CalledWithId_ReturnsReponseWithId()
         {
             // Given
             var response = new OrganizationMembershipResponse { Item = new OrganizationMembership { Id = 123 } };
@@ -132,7 +220,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var organizationMembershipResource = new OrganizationMembershipResource(_client.Object);
 
             // When
-            var result = organizationMembershipResource.Post(request);
+            var result = await organizationMembershipResource.PostAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));

--- a/src/ZendeskApi.Client.Tests/Resources/OrganizationResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/OrganizationResourceFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using ZendeskApi.Client.Http;
 using ZendeskApi.Client.Resources;
 using ZendeskApi.Contracts.Models;
@@ -35,7 +34,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://search"));
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            await resource.GetAsync(321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("321")), ""));
+        }
+
+        [Test]
         public void Get_Called_ReturnsResponse()
+        {
+            // Given
+            var response = new OrganizationResponse { Item = new Organization { Id = 1 } };
+            _client.Setup(b => b.Get<OrganizationResponse>(It.IsAny<Uri>())).Returns(response);
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            var result = resource.Get(321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAsync_Called_ReturnsResponse()
         {
             // Given
             var response = new OrganizationResponse { Item = new Organization { Id = 1 } };
@@ -43,7 +71,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new OrganizationResource(_client.Object);
 
             // When
-            var result = resource.Get(321);
+            var result = await resource.GetAsync(321);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -64,7 +92,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PutAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new OrganizationRequest { Item = new Organization { Name = "Organizations", Id = 123 } };
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            await resource.PutAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Put_CalledWithItem_ReturnsReponse()
+        {
+            // Given
+            var response = new OrganizationResponse { Item = new Organization { Name = "blah blah" } };
+            var request = new OrganizationRequest { Item = new Organization { Name = "blah blah", Id = 123 } };
+            _client.Setup(b => b.Put<OrganizationResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            var result = resource.Put(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PutAsync_CalledWithItem_ReturnsReponse()
         {
             // Given
             var response = new OrganizationResponse { Item = new Organization { Name = "blah blah" } };
@@ -73,7 +131,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new OrganizationResource(_client.Object);
 
             // When
-            var result = resource.Put(request);
+            var result = await resource.PutAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -85,11 +143,24 @@ namespace ZendeskApi.Client.Tests.Resources
             // Given
             var response = new OrganizationResponse { Item = new Organization { Name = "blah blah" } };
             var request = new OrganizationRequest { Item = new Organization { Name = "blah blah" } };
+            _client.Setup(b => b.Put<OrganizationResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var resource = new OrganizationResource(_client.Object);
+
+            // When, Then
+            Assert.Throws<ArgumentException>(() => resource.Put(request));
+        }
+
+        [Test]
+        public void PutAsync_HasNoId_ThrowsException()
+        {
+            // Given
+            var response = new OrganizationResponse { Item = new Organization { Name = "blah blah" } };
+            var request = new OrganizationRequest { Item = new Organization { Name = "blah blah" } };
             _client.Setup(b => b.PutAsync<OrganizationResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(TaskHelper.CreateTaskFromResult(response));
             var resource = new OrganizationResource(_client.Object);
 
             // When, Then
-            Assert.Throws<AggregateException>(() => resource.Put(request));
+            Assert.Throws<ArgumentException>(async () => await resource.PutAsync(request));
         }
 
         [Test]
@@ -107,7 +178,38 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PostAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new OrganizationRequest { Item = new Organization { Name = "blah blah" } };
+            var resource = new OrganizationResource(_client.Object);
+            
+            // When
+            await resource.PostAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Post_CalledWithItem_ReturnsReponse()
+        {
+            // Given
+            var response = new OrganizationResponse { Item = new Organization { Name = "blah blah" } };
+            var request = new OrganizationRequest { Item = new Organization { Name = "blah blah" } };
+            _client.Setup(b => b.Post<OrganizationResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            var result = resource.Post(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+
+        [Test]
+        public async void PostAsync_CalledWithItem_ReturnsReponse()
         {
             // Given
             var response = new OrganizationResponse { Item = new Organization { Name = "blah blah" } };
@@ -116,7 +218,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new OrganizationResource(_client.Object);
 
             // When
-            var result = resource.Post(request);
+            var result = await resource.PostAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -137,7 +239,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void DeleteAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://search"));
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            await resource.DeleteAsync(321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("321")), ""));
+        }
+
+        [Test]
         public void Delete_Called_CallsDeleteOnClient()
+        {
+            // Given
+            var response = new OrganizationResponse { Item = new Organization { Id = 1 } };
+            _client.Setup(b => b.Get<OrganizationResponse>(It.IsAny<Uri>())).Returns(response);
+            var resource = new OrganizationResource(_client.Object);
+
+            // When
+            resource.Delete(321);
+
+            // Then
+            _client.Verify(c => c.Delete(It.IsAny<Uri>()));
+        }
+
+        [Test]
+        public async void DeleteAsync_Called_CallsDeleteOnClient()
         {
             // Given
             var response = new OrganizationResponse { Item = new Organization { Id = 1 } };
@@ -145,7 +276,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new OrganizationResource(_client.Object);
 
             // When
-            resource.Delete(321);
+            await resource.DeleteAsync(321);
 
             // Then
             _client.Verify(c => c.DeleteAsync(It.IsAny<Uri>()));

--- a/src/ZendeskApi.Client.Tests/Resources/RequestCommentResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/RequestCommentResourceFixture.cs
@@ -24,11 +24,26 @@ namespace ZendeskApi.Client.Tests.Resources
         {
             //Given
             var response = new TicketCommentListResponse();
-            _client.Setup(c => c.GetAsync<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            _client.Setup(c => c.Get<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(response);
             var resource = new RequestCommentResource(_client.Object);
 
             //When
             resource.Get(321, 123);
+
+            //Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(u => u.Contains("requests/123/comments/321")), It.IsAny<string>()));
+        }
+
+        [Test]
+        public async void GetAsync_Called_UrlIsCorrect()
+        {
+            //Given
+            var response = new TicketCommentListResponse();
+            _client.Setup(c => c.GetAsync<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            var resource = new RequestCommentResource(_client.Object);
+
+            //When
+            await resource.GetAsync(321, 123);
 
             //Then
             _client.Verify(c => c.BuildUri(It.Is<string>(u => u.Contains("requests/123/comments/321")), It.IsAny<string>()));
@@ -42,7 +57,7 @@ namespace ZendeskApi.Client.Tests.Resources
             {
                 Results = new List<TicketComment> { new TicketComment { Id = 123 } }
             };
-            _client.Setup(c => c.GetAsync<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            _client.Setup(c => c.Get<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(response);
             var resource = new RequestCommentResource(_client.Object);
 
             //When
@@ -53,7 +68,40 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAllAsync_CalledWithId_ReturnsListOfComments()
+        {
+            //Given
+            var response = new TicketCommentListResponse
+            {
+                Results = new List<TicketComment> { new TicketComment { Id = 123 } }
+            };
+            _client.Setup(c => c.GetAsync<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            var resource = new RequestCommentResource(_client.Object);
+
+            //When
+            var result = await resource.GetAllAsync(123);
+
+            //Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
         public void GetAll_Called_UrlIsCorrect()
+        {
+            //Given
+            var response = new TicketCommentListResponse();
+            _client.Setup(c => c.Get<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(response);
+            var resource = new RequestCommentResource(_client.Object);
+
+            //When
+            resource.GetAll(123);
+
+            //Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(u => u.Contains("requests/123/comments")), It.IsAny<string>()));
+        }
+
+        [Test]
+        public async void GetAllAsync_Called_UrlIsCorrect()
         {
             //Given
             var response = new TicketCommentListResponse();
@@ -61,7 +109,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new RequestCommentResource(_client.Object);
 
             //When
-            resource.GetAll(123);
+            await resource.GetAllAsync(123);
 
             //Then
             _client.Verify(c => c.BuildUri(It.Is<string>(u => u.Contains("requests/123/comments")), It.IsAny<string>()));

--- a/src/ZendeskApi.Client.Tests/Resources/RequestResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/RequestResourceFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using ZendeskApi.Client.Http;
 using ZendeskApi.Client.Resources;
 using ZendeskApi.Contracts.Models;
@@ -36,7 +35,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://search"));
+            var resource = new RequestResource(_client.Object);
+
+            // When
+            await resource.GetAsync(321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("321")), ""));
+        }
+
+        [Test]
         public void Get_Called_ReturnsRequestResponse()
+        {
+            // Given
+            var response = new RequestResponse { Item = new Request { Id = 1 } };
+            _client.Setup(b => b.Get<RequestResponse>(It.IsAny<Uri>())).Returns(response);
+            var resource = new RequestResource(_client.Object);
+
+            // When
+            var result = resource.Get(321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAsync_Called_ReturnsRequestResponse()
         {
             // Given
             var response = new RequestResponse { Item = new Request { Id = 1 } };
@@ -44,7 +72,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new RequestResource(_client.Object);
 
             // When
-            var result = resource.Get(321);
+            var result = await resource.GetAsync(321);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -66,6 +94,21 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAsync_CalledWithStatuses_CallsBuildUriWithStatuses()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://search"));
+            var resource = new RequestResource(_client.Object);
+            var statuses = new List<TicketStatus> {TicketStatus.Hold, TicketStatus.Open};
+
+            // When
+            await resource.GetAsync(statuses);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("requests")), It.Is<string>(s => s.Contains("status=hold,open"))));
+        }
+
+        [Test]
         public void Put_Called_BuildsUri()
         {
             // Given
@@ -80,7 +123,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PutAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new RequestRequest { Item = new Request { Subject = "blah blah", Id = 123 } };
+            var resource = new RequestResource(_client.Object);
+
+            // When
+            await resource.PutAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Put_CalledWithRequest_ReturnsRequestReponse()
+        {
+            // Given
+            var response = new RequestResponse { Item = new Request { Subject = "blah blah" } };
+            var request = new RequestRequest { Item = new Request { Subject = "blah blah", Id = 123 } };
+            _client.Setup(b => b.Put<RequestResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var resource = new RequestResource(_client.Object);
+
+            // When
+            var result = resource.Put(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PutAsync_CalledWithRequest_ReturnsRequestReponse()
         {
             // Given
             var response = new RequestResponse { Item = new Request { Subject = "blah blah" } };
@@ -89,7 +162,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new RequestResource(_client.Object);
 
             // When
-            var result = resource.Put(request);
+            var result = await resource.PutAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -101,11 +174,24 @@ namespace ZendeskApi.Client.Tests.Resources
             // Given
             var response = new RequestResponse { Item = new Request { Subject = "blah blah" } };
             var request = new RequestRequest { Item = new Request { Subject = "blah blah" } };
+            _client.Setup(b => b.Put<RequestResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var requestResource = new RequestResource(_client.Object);
+
+            // When, Then
+            Assert.Throws<ArgumentException>(() => requestResource.Put(request));
+        }
+
+        [Test]
+        public void PutAsync_RequestHasNoId_ThrowsException()
+        {
+            // Given
+            var response = new RequestResponse { Item = new Request { Subject = "blah blah" } };
+            var request = new RequestRequest { Item = new Request { Subject = "blah blah" } };
             _client.Setup(b => b.PutAsync<RequestResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(TaskHelper.CreateTaskFromResult(response));
             var requestResource = new RequestResource(_client.Object);
 
             // When, Then
-            Assert.Throws<AggregateException>(() => requestResource.Put(request));
+            Assert.Throws<ArgumentException>(async () => await requestResource.PutAsync(request));
         }
 
         [Test]
@@ -123,7 +209,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PostAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new RequestRequest { Item = new Request { Subject = "blah blah" } };
+            var requestResource = new RequestResource(_client.Object);
+
+            // When
+            await requestResource.PostAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Post_CalledWithRequest_ReturnsRequestReponse()
+        {
+            // Given
+            var response = new RequestResponse { Item = new Request { Subject = "blah blah" } };
+            var request = new RequestRequest { Item = new Request { Subject = "blah blah" } };
+            _client.Setup(b => b.Post<RequestResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var requestResource = new RequestResource(_client.Object);
+
+            // When
+            var result = requestResource.Post(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PostAsync_CalledWithRequest_ReturnsRequestReponse()
         {
             // Given
             var response = new RequestResponse { Item = new Request { Subject = "blah blah" } };
@@ -132,7 +248,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var requestResource = new RequestResource(_client.Object);
 
             // When
-            var result = requestResource.Post(request);
+            var result = await requestResource.PostAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -153,7 +269,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void DeleteAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://search"));
+            var requestResource = new RequestResource(_client.Object);
+
+            // When
+            await requestResource.DeleteAsync(321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("321")), ""));
+        }
+
+        [Test]
         public void Delete_Called_CallsDeleteOnClient()
+        {
+            // Given
+            var response = new RequestResponse { Item = new Request { Id = 1 } };
+            _client.Setup(b => b.Get<RequestResponse>(It.IsAny<Uri>())).Returns(response);
+            var requestResource = new RequestResource(_client.Object);
+
+            // When
+            requestResource.Delete(321);
+
+            // Then
+            _client.Verify(c => c.Delete(It.IsAny<Uri>()));
+        }
+
+        [Test]
+        public async void DeleteAsync_Called_CallsDeleteOnClient()
         {
             // Given
             var response = new RequestResponse { Item = new Request { Id = 1 } };
@@ -161,7 +306,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var requestResource = new RequestResource(_client.Object);
 
             // When
-            requestResource.Delete(321);
+            await requestResource.DeleteAsync(321);
 
             // Then
             _client.Verify(c => c.DeleteAsync(It.IsAny<Uri>()));

--- a/src/ZendeskApi.Client.Tests/Resources/SatisfactionRatingResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/SatisfactionRatingResourceFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using ZendeskApi.Client.Http;
 using ZendeskApi.Client.Resources;
 using ZendeskApi.Contracts.Models;
@@ -34,9 +33,39 @@ namespace ZendeskApi.Client.Tests.Resources
             _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("/satisfaction_ratings/321")), ""));
         }
 
+        [Test]
+        public async void GetAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://zendesk"));
+            var resource = new SatisfactionRatingResource(_client.Object);
+
+            // When
+            await resource.GetAsync(321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("/satisfaction_ratings/321")), ""));
+        }
+
 
         [Test]
         public void Get_Called_ReturnsResponse()
+        {
+            // Given
+            var response = new SatisfactionRatingResponse { Item = new SatisfactionRating { Id = 1 }};
+            _client.Setup(b => b.Get<SatisfactionRatingResponse>(It.IsAny<Uri>())).Returns(response);
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321")))).Returns(new Uri("http://zendesk"));
+            var resource = new SatisfactionRatingResource(_client.Object);
+
+            // When
+            var result = resource.Get(321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAsync_Called_ReturnsResponse()
         {
             // Given
             var response = new SatisfactionRatingResponse { Item = new SatisfactionRating { Id = 1 }};
@@ -45,7 +74,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new SatisfactionRatingResource(_client.Object);
 
             // When
-            var result = resource.Get(321);
+            var result = await resource.GetAsync(321);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -66,7 +95,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PostAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new SatisfactionRatingRequest { Item = new SatisfactionRating { Score = SatisfactionRatingScore.good } };
+            var resource = new SatisfactionRatingResource(_client.Object);
+
+            // When
+            await resource.PostAsync(request, 231);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Post_CalledWithRating_ReturnsUserReponse()
+        {
+            // Given
+            var response = new SatisfactionRatingResponse { Item = new SatisfactionRating { Score = SatisfactionRatingScore.good } };
+            var request = new SatisfactionRatingRequest { Item = new SatisfactionRating { Score = SatisfactionRatingScore.good } };
+            _client.Setup(b => b.Post<SatisfactionRatingResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var resource = new SatisfactionRatingResource(_client.Object);
+
+            // When
+            var result = resource.Post(request, 21);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PostAsync_CalledWithRating_ReturnsUserReponse()
         {
             // Given
             var response = new SatisfactionRatingResponse { Item = new SatisfactionRating { Score = SatisfactionRatingScore.good } };
@@ -75,7 +134,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new SatisfactionRatingResource(_client.Object);
 
             // When
-            var result = resource.Post(request, 21);
+            var result = await resource.PostAsync(request, 21);
 
             // Then
             Assert.That(result, Is.EqualTo(response));

--- a/src/ZendeskApi.Client.Tests/Resources/SearchResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/SearchResourceFixture.cs
@@ -38,6 +38,22 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void FindAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321"))))
+                .Returns(new Uri("http://search"));
+            var searchResource = new SearchResource(_client.Object);
+            _query.Setup(q => q.BuildQuery()).Returns("query");
+
+            // When
+            await searchResource.FindAsync(_query.Object);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("search")), It.Is<string>(s => s.Contains("query"))));
+        }
+
+        [Test]
         public void Find_Called_CallsGetOnClient()
         {
             // Given
@@ -48,6 +64,22 @@ namespace ZendeskApi.Client.Tests.Resources
 
             // When
             searchResource.Find(_query.Object);
+
+            // Then
+            _client.Verify(c => c.Get<ListResponse<Organization>>(It.IsAny<Uri>()));
+        }
+
+        [Test]
+        public async void FindAsync_Called_CallsGetOnClient()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("321"))))
+                .Returns(new Uri("http://search"));
+            _query.Setup(q => q.BuildQuery()).Returns("query");
+            var searchResource = new SearchResource(_client.Object);
+
+            // When
+            await searchResource.FindAsync(_query.Object);
 
             // Then
             _client.Verify(c => c.GetAsync<ListResponse<Organization>>(It.IsAny<Uri>()));

--- a/src/ZendeskApi.Client.Tests/Resources/TicketCommentResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/TicketCommentResourceFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using ZendeskApi.Client.Http;
 using ZendeskApi.Client.Resources;
 using ZendeskApi.Contracts.Models;
@@ -28,7 +27,7 @@ namespace ZendeskApi.Client.Tests.Resources
             {
                 Results = new List<TicketComment> { new TicketComment { Id = 123 } }
             };
-            _client.Setup(c => c.GetAsync<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            _client.Setup(c => c.Get<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(response);
             var resource = new TicketCommentResource(_client.Object);
 
             //When
@@ -39,7 +38,40 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAllAsync_CalledWithId_ReturnsListOfComments()
+        {
+            //Given
+            var response = new TicketCommentListResponse
+            {
+                Results = new List<TicketComment> { new TicketComment { Id = 123 } }
+            };
+            _client.Setup(c => c.GetAsync<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(TaskHelper.CreateTaskFromResult(response));
+            var resource = new TicketCommentResource(_client.Object);
+
+            //When
+            var result = await resource.GetAllAsync(123);
+
+            //Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
         public void GetAll_Called_UrlIsCorrect()
+        {
+            //Given
+            var response = new TicketCommentListResponse();
+            _client.Setup(c => c.Get<TicketCommentListResponse>(It.IsAny<Uri>())).Returns(response);
+            var resource = new TicketCommentResource(_client.Object);
+
+            //When
+            resource.GetAll(123);
+
+            //Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(u => u.Contains("tickets/123/comments")), It.IsAny<string>()));
+        }
+
+        [Test]
+        public async void GetAllAsync_Called_UrlIsCorrect()
         {
             //Given
             var response = new TicketCommentListResponse();
@@ -47,7 +79,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var resource = new TicketCommentResource(_client.Object);
 
             //When
-            resource.GetAll(123);
+            await resource.GetAllAsync(123);
 
             //Then
             _client.Verify(c => c.BuildUri(It.Is<string>(u => u.Contains("tickets/123/comments")), It.IsAny<string>()));

--- a/src/ZendeskApi.Client.Tests/Resources/UserIdentityResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/UserIdentityResourceFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using ZendeskApi.Client.Http;
 using ZendeskApi.Client.Resources;
 using ZendeskApi.Contracts.Models;
@@ -36,7 +35,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAllAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("http://search"));
+            var userIdentityResource = new UserIdentityResource(_client.Object);
+
+            // When
+            await userIdentityResource.GetAllAsync(4321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(st => st.Contains("4321")), ""));
+        }
+
+        [Test]
         public void GetAll_Called_ReturnsUserIdentityResponse()
+        {
+            // Given
+            var response = new UserIdentityListResponse { Results = new List<UserIdentity> { new UserIdentity { Id = 1 } } };
+            _client.Setup(b => b.Get<UserIdentityListResponse>(It.IsAny<Uri>())).Returns(response);
+            var userIdentityResource = new UserIdentityResource(_client.Object);
+
+            // When
+            var result = userIdentityResource.GetAll(4321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAllAsync_Called_ReturnsUserIdentityResponse()
         {
             // Given
             var response = new UserIdentityListResponse { Results = new List<UserIdentity> { new UserIdentity { Id = 1 } } };
@@ -44,7 +72,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userIdentityResource = new UserIdentityResource(_client.Object);
 
             // When
-            var result = userIdentityResource.GetAll(4321);
+            var result = await userIdentityResource.GetAllAsync(4321);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -65,7 +93,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PostAsync_Called_BuildsUriWithFieldUserId()
+        {
+            // Given
+            var request = new UserIdentityRequest { Item = new UserIdentity { Name = "email", UserId = 1234 } };
+            var userIdentityResource = new UserIdentityResource(_client.Object);
+
+            // When
+            await userIdentityResource.PostAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.Is<string>(s => s.Contains("1234")), ""));
+        }
+
+        [Test]
         public void Post_CalledWithUser_ReturnsUserReponse()
+        {
+            // Given
+            var response = new UserIdentityResponse { Item = new UserIdentity { Name = "email" } };
+            var request = new UserIdentityRequest { Item = new UserIdentity { Name = "email" } };
+            _client.Setup(b => b.Post<UserIdentityResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var userIdentityResource = new UserIdentityResource(_client.Object);
+
+            // When
+            var result = userIdentityResource.Post(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PostAsync_CalledWithUser_ReturnsUserReponse()
         {
             // Given
             var response = new UserIdentityResponse { Item = new UserIdentity { Name = "email" } };
@@ -74,7 +132,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userIdentityResource = new UserIdentityResource(_client.Object);
 
             // When
-            var result = userIdentityResource.Post(request);
+            var result = await userIdentityResource.PostAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -95,7 +153,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PutAsync_Called_BuildsUriWithFieldUserId()
+        {
+            // Given
+            var request = new UserIdentityRequest { Item = new UserIdentity { Name = "email", UserId = 1234, Id = 123 } };
+            var userIdentityResource = new UserIdentityResource(_client.Object);
+
+            // When
+            await userIdentityResource.PutAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.Is<string>(s => s.Contains("1234")), ""));
+        }
+
+        [Test]
         public void Put_CalledWithUser_ReturnsUserReponse()
+        {
+            // Given
+            var response = new UserIdentityResponse { Item = new UserIdentity { Name = "email", Id = 123 } };
+            var request = new UserIdentityRequest { Item = new UserIdentity { Name = "email", Id = 123 } };
+            _client.Setup(b => b.Put<UserIdentityResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var userIdentityResource = new UserIdentityResource(_client.Object);
+
+            // When
+            var result = userIdentityResource.Put(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PutAsync_CalledWithUser_ReturnsUserReponse()
         {
             // Given
             var response = new UserIdentityResponse { Item = new UserIdentity { Name = "email", Id = 123 } };
@@ -104,7 +192,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userIdentityResource = new UserIdentityResource(_client.Object);
 
             // When
-            var result = userIdentityResource.Put(request);
+            var result = await userIdentityResource.PutAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));

--- a/src/ZendeskApi.Client.Tests/Resources/UserResourceFixture.cs
+++ b/src/ZendeskApi.Client.Tests/Resources/UserResourceFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using ZendeskApi.Client.Http;
 using ZendeskApi.Client.Resources;
 using ZendeskApi.Contracts.Models;
@@ -36,7 +35,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.Is<string>(s => s.Contains("4321")))).Returns(new Uri("http://search"));
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            await userResource.GetAsync(4321);
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("4321")), ""));
+        }
+
+        [Test]
         public void Get_Called_ReturnsUserResponse()
+        {
+            // Given
+            var response = new UserResponse { Item = new User { Id = 1 } };
+            _client.Setup(b => b.Get<UserResponse>(It.IsAny<Uri>())).Returns(response);
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            var result = userResource.Get(4321);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAsync_Called_ReturnsUserResponse()
         {
             // Given
             var response = new UserResponse { Item = new User { Id = 1 } };
@@ -44,7 +72,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userResource = new UserResource(_client.Object);
 
             // When
-            var result = userResource.Get(4321);
+            var result = await userResource.GetAsync(4321);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -65,7 +93,36 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void GetAllAsync_Called_CallsBuildUriWithFieldId()
+        {
+            // Given
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("http://search"));
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            await userResource.GetAllAsync(new List<long> { 4321, 3456, 6789 });
+
+            // Then
+            _client.Verify(c => c.BuildUri(It.Is<string>(s => s.Contains("/show_many")), It.Is<string>(st => st.Contains("4321,3456,6789"))));
+        }
+
+        [Test]
         public void GetAll_Called_ReturnsUserResponse()
+        {
+            // Given
+            var response = new UserListResponse { Results = new List<User> { new User { Id = 1 } } };
+            _client.Setup(b => b.Get<UserListResponse>(It.IsAny<Uri>())).Returns(response);
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            var result = userResource.GetAll(new List<long> { 4321, 3456, 6789 });
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void GetAllAsync_Called_ReturnsUserResponse()
         {
             // Given
             var response = new UserListResponse { Results = new List<User> { new User { Id = 1 } } };
@@ -73,7 +130,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userResource = new UserResource(_client.Object);
 
             // When
-            var result = userResource.GetAll(new List<long> { 4321, 3456, 6789 });
+            var result = await userResource.GetAllAsync(new List<long> { 4321, 3456, 6789 });
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -94,7 +151,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PostAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new UserRequest { Item = new User { Name = "Owner Name" } };
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            await userResource.PostAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Post_CalledWithUser_ReturnsUserReponse()
+        {
+            // Given
+            var response = new UserResponse { Item = new User { Name = "Owner Name" } };
+            var request = new UserRequest { Item = new User { Name = "Owner Name" } };
+            _client.Setup(b => b.Post<UserResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            var result = userResource.Post(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PostAsync_CalledWithUser_ReturnsUserReponse()
         {
             // Given
             var response = new UserResponse { Item = new User { Name = "Owner Name" } };
@@ -103,7 +190,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userResource = new UserResource(_client.Object);
 
             // When
-            var result = userResource.Post(request);
+            var result = await userResource.PostAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));
@@ -124,7 +211,37 @@ namespace ZendeskApi.Client.Tests.Resources
         }
 
         [Test]
+        public async void PutAsync_Called_BuildsUri()
+        {
+            // Given
+            var request = new UserRequest { Item = new User { Name = "Owner Name", Id = 123 } };
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            await userResource.PutAsync(request);
+
+            // Then
+            _client.Setup(b => b.BuildUri(It.IsAny<string>(), ""));
+        }
+
+        [Test]
         public void Put_CalledWithUser_ReturnsUserReponse()
+        {
+            // Given
+            var response = new UserResponse { Item = new User { Name = "Owner Name" } };
+            var request = new UserRequest { Item = new User { Name = "Owner Name", Id = 123 } };
+            _client.Setup(b => b.Put<UserResponse>(It.IsAny<Uri>(), request, "application/json")).Returns(response);
+            var userResource = new UserResource(_client.Object);
+
+            // When
+            var result = userResource.Put(request);
+
+            // Then
+            Assert.That(result, Is.EqualTo(response));
+        }
+
+        [Test]
+        public async void PutAsync_CalledWithUser_ReturnsUserReponse()
         {
             // Given
             var response = new UserResponse { Item = new User { Name = "Owner Name" } };
@@ -133,7 +250,7 @@ namespace ZendeskApi.Client.Tests.Resources
             var userResource = new UserResource(_client.Object);
 
             // When
-            var result = userResource.Put(request);
+            var result = await userResource.PutAsync(request);
 
             // Then
             Assert.That(result, Is.EqualTo(response));

--- a/src/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
+++ b/src/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
@@ -39,6 +39,8 @@
     <!--If configuration is not provided, default to Debug build-->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <OutputPath>bin\$(Configuration)\$(NugetFrameworkVersion)\</OutputPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Choose>
     <When Condition="$(Configuration.Contains('Debug'))">
@@ -56,6 +58,10 @@
     </When>
   </Choose>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -68,11 +74,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\$(NugetFrameworkVersion)\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
@@ -138,5 +145,12 @@
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="bin" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
 </Project>

--- a/src/ZendeskApi.Client.Tests/ZendeskClientFixture.cs
+++ b/src/ZendeskApi.Client.Tests/ZendeskClientFixture.cs
@@ -80,6 +80,20 @@ namespace ZendeskApi.Client.Tests
         }
 
         [Test]
+        public void GetAsync_HttpReturnsFailResult_ThrowsException()
+        {
+            // Given
+            var http = new Mock<IHttpChannel>();
+            http.Setup(h => h.GetAsync(It.IsAny<IHttpRequest>()))
+                .Returns(TaskHelper.CreateTaskFromResult(_failureResponse));
+
+            var client = new ZendeskClient(new Uri("http://someurl.co.uk"), new ZendeskDefaultConfiguration("bob", "x1234//#"), _serializer.Object, http.Object);
+
+            // When, Then
+            Assert.Throws<HttpException>(async () => await client.GetAsync<string>(new Uri("http://someurl.co.uk/resource")));
+        }
+
+        [Test]
         public void Put_Success_ReturnsSuccessResult()
         {
             // Given
@@ -196,6 +210,20 @@ namespace ZendeskApi.Client.Tests
 
             // When, Then
             Assert.Throws<HttpException>(() => client.Post<string>(new Uri("http://someurl.co.uk/resource")));
+        }
+
+        [Test]
+        public void PostAsync_HttpReturnsFailResult_ThrowsException()
+        {
+            // Given
+            var http = new Mock<IHttpChannel>();
+            http.Setup(h => h.PostAsync(It.IsAny<IHttpRequest>()))
+                .Returns(TaskHelper.CreateTaskFromResult(_failureResponse));
+
+            var client = new ZendeskClient(new Uri("http://someurl.co.uk"), new ZendeskDefaultConfiguration("bob", "x1234//#"), _serializer.Object, http.Object);
+
+            // When, Then
+            Assert.Throws<HttpException>(async () => await client.PostAsync<string>(new Uri("http://someurl.co.uk/resource")));
         }
 
         [Test]

--- a/src/ZendeskApi.Client.Tests/packages.config
+++ b/src/ZendeskApi.Client.Tests/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net40" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
-  <package id="Moq" version="4.2.1402.2112" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />

--- a/src/ZendeskApi.Client.Tests/packages.config
+++ b/src/ZendeskApi.Client.Tests/packages.config
@@ -6,4 +6,5 @@
   <package id="Moq" version="4.2.1402.2112" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Client.Tests/packages.config
+++ b/src/ZendeskApi.Client.Tests/packages.config
@@ -7,5 +7,4 @@
   <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Client/ClientBase.cs
+++ b/src/ZendeskApi.Client/ClientBase.cs
@@ -57,7 +57,7 @@ namespace ZendeskApi.Client
         public async Task<T> GetAsync<T>(Uri requestUri)
         {
             var request = BuildRequest(requestUri);
-            var response = await _http.GetAsync(request);
+            var response = await _http.GetAsync(request).ConfigureAwait(false);
             ValidateResponse(response);
             return DeserializeContent<T>(response);
         }
@@ -81,7 +81,7 @@ namespace ZendeskApi.Client
         public async Task<T> PostAsync<T>(Uri requestUri, object item = null, string contentType = "application/json")
         {
             var request = BuildRequest(requestUri, item, contentType);
-            var response = await _http.PostAsync(request);
+            var response = await _http.PostAsync(request).ConfigureAwait(false);
             ValidateResponse(response);
             return DeserializeContent<T>(response);
         }
@@ -97,7 +97,7 @@ namespace ZendeskApi.Client
         public async Task<T> PutAsync<T>(Uri requestUri, object item = null, string contentType = "application/json")
         {
             var request = BuildRequest(requestUri, item, contentType);
-            var response = await _http.PutAsync(request);
+            var response = await _http.PutAsync(request).ConfigureAwait(false);
             ValidateResponse(response);
             return DeserializeContent<T>(response);
         }
@@ -110,7 +110,7 @@ namespace ZendeskApi.Client
         public async Task DeleteAsync(Uri requestUri)
         {
             var request = BuildRequest(requestUri);
-            var response = await _http.DeleteAsync(request);
+            var response = await _http.DeleteAsync(request).ConfigureAwait(false);
             ValidateResponse(response);
         }
 

--- a/src/ZendeskApi.Client/ClientBase.cs
+++ b/src/ZendeskApi.Client/ClientBase.cs
@@ -57,7 +57,7 @@ namespace ZendeskApi.Client
         public async Task<T> GetAsync<T>(Uri requestUri)
         {
             var request = BuildRequest(requestUri);
-            var response = await _http.GetAsync(request).ConfigureAwait(false);
+            var response = await _http.GetAsync(request);
             ValidateResponse(response);
             return DeserializeContent<T>(response);
         }
@@ -81,7 +81,7 @@ namespace ZendeskApi.Client
         public async Task<T> PostAsync<T>(Uri requestUri, object item = null, string contentType = "application/json")
         {
             var request = BuildRequest(requestUri, item, contentType);
-            var response = await _http.PostAsync(request).ConfigureAwait(false);
+            var response = await _http.PostAsync(request);
             ValidateResponse(response);
             return DeserializeContent<T>(response);
         }
@@ -97,7 +97,7 @@ namespace ZendeskApi.Client
         public async Task<T> PutAsync<T>(Uri requestUri, object item = null, string contentType = "application/json")
         {
             var request = BuildRequest(requestUri, item, contentType);
-            var response = await _http.PutAsync(request).ConfigureAwait(false);
+            var response = await _http.PutAsync(request);
             ValidateResponse(response);
             return DeserializeContent<T>(response);
         }
@@ -110,7 +110,7 @@ namespace ZendeskApi.Client
         public async Task DeleteAsync(Uri requestUri)
         {
             var request = BuildRequest(requestUri);
-            var response = await _http.DeleteAsync(request).ConfigureAwait(false);
+            var response = await _http.DeleteAsync(request);
             ValidateResponse(response);
         }
 

--- a/src/ZendeskApi.Client/Http/HttpChannel.cs
+++ b/src/ZendeskApi.Client/Http/HttpChannel.cs
@@ -28,8 +28,8 @@ namespace ZendeskApi.Client.Http
                 ConfigureRequest(request, client);
                 try
                 {
-                    using (var responseMessage = await client.GetAsync(request.RequestUri).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
+                    using (var responseMessage = await client.GetAsync(request.RequestUri))
+                        response = await BuildResponseAsync(responseMessage);
                 }
                 catch (WebException ex)
                 {
@@ -77,8 +77,8 @@ namespace ZendeskApi.Client.Http
                 try
                 {
                     var content = BuildHttpContent(request);
-                    using (var responseMessage = await client.PostAsync(request.RequestUri, content).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
+                    using (var responseMessage = await client.PostAsync(request.RequestUri, content))
+                        response = await BuildResponseAsync(responseMessage);
                 }
                 catch (WebException ex)
                 {
@@ -106,8 +106,8 @@ namespace ZendeskApi.Client.Http
                 try
                 {
                     var content = BuildHttpContent(request);
-                    using (var responseMessage = await client.PutAsync(request.RequestUri, content).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
+                    using (var responseMessage = await client.PutAsync(request.RequestUri, content))
+                        response = await BuildResponseAsync(responseMessage);
                 }
                 catch (WebException ex)
                 {
@@ -134,8 +134,8 @@ namespace ZendeskApi.Client.Http
                 ConfigureRequest(request, client);
                 try
                 {
-                    using (var responseMessage = await client.DeleteAsync(request.RequestUri).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
+                    using (var responseMessage = await client.DeleteAsync(request.RequestUri))
+                        response = await BuildResponseAsync(responseMessage);
                 }
                 catch (WebException ex)
                 {
@@ -388,7 +388,7 @@ namespace ZendeskApi.Client.Http
                 Headers = GetResponseHeaders(responseMessage.Headers),
                 StatusCode = responseMessage.StatusCode,
                 ReasonPhrase = responseMessage.ReasonPhrase,
-                Content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false)
+                Content = await responseMessage.Content.ReadAsStringAsync()
             };
             return response;
         }

--- a/src/ZendeskApi.Client/Http/HttpChannel.cs
+++ b/src/ZendeskApi.Client/Http/HttpChannel.cs
@@ -28,8 +28,8 @@ namespace ZendeskApi.Client.Http
                 ConfigureRequest(request, client);
                 try
                 {
-                    using (var responseMessage = await client.GetAsync(request.RequestUri))
-                        response = await BuildResponseAsync(responseMessage);
+                    using (var responseMessage = await client.GetAsync(request.RequestUri).ConfigureAwait(false))
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -77,8 +77,8 @@ namespace ZendeskApi.Client.Http
                 try
                 {
                     var content = BuildHttpContent(request);
-                    using (var responseMessage = await client.PostAsync(request.RequestUri, content))
-                        response = await BuildResponseAsync(responseMessage);
+                    using (var responseMessage = await client.PostAsync(request.RequestUri, content).ConfigureAwait(false))
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -106,8 +106,8 @@ namespace ZendeskApi.Client.Http
                 try
                 {
                     var content = BuildHttpContent(request);
-                    using (var responseMessage = await client.PutAsync(request.RequestUri, content))
-                        response = await BuildResponseAsync(responseMessage);
+                    using (var responseMessage = await client.PutAsync(request.RequestUri, content).ConfigureAwait(false))
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -134,8 +134,8 @@ namespace ZendeskApi.Client.Http
                 ConfigureRequest(request, client);
                 try
                 {
-                    using (var responseMessage = await client.DeleteAsync(request.RequestUri))
-                        response = await BuildResponseAsync(responseMessage);
+                    using (var responseMessage = await client.DeleteAsync(request.RequestUri).ConfigureAwait(false))
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -388,7 +388,7 @@ namespace ZendeskApi.Client.Http
                 Headers = GetResponseHeaders(responseMessage.Headers),
                 StatusCode = responseMessage.StatusCode,
                 ReasonPhrase = responseMessage.ReasonPhrase,
-                Content = await responseMessage.Content.ReadAsStringAsync()
+                Content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false)
             };
             return response;
         }

--- a/src/ZendeskApi.Client/Http/HttpChannel.cs
+++ b/src/ZendeskApi.Client/Http/HttpChannel.cs
@@ -29,7 +29,7 @@ namespace ZendeskApi.Client.Http
                 try
                 {
                     using (var responseMessage = await client.GetAsync(request.RequestUri).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage);
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -78,7 +78,7 @@ namespace ZendeskApi.Client.Http
                 {
                     var content = BuildHttpContent(request);
                     using (var responseMessage = await client.PostAsync(request.RequestUri, content).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage);
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -107,7 +107,7 @@ namespace ZendeskApi.Client.Http
                 {
                     var content = BuildHttpContent(request);
                     using (var responseMessage = await client.PutAsync(request.RequestUri, content).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage);
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -135,7 +135,7 @@ namespace ZendeskApi.Client.Http
                 try
                 {
                     using (var responseMessage = await client.DeleteAsync(request.RequestUri).ConfigureAwait(false))
-                        response = await BuildResponseAsync(responseMessage);
+                        response = await BuildResponseAsync(responseMessage).ConfigureAwait(false);
                 }
                 catch (WebException ex)
                 {
@@ -388,7 +388,7 @@ namespace ZendeskApi.Client.Http
                 Headers = GetResponseHeaders(responseMessage.Headers),
                 StatusCode = responseMessage.StatusCode,
                 ReasonPhrase = responseMessage.ReasonPhrase,
-                Content = await responseMessage.Content.ReadAsStringAsync()
+                Content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false)
             };
             return response;
         }

--- a/src/ZendeskApi.Client/Http/IRestClient.cs
+++ b/src/ZendeskApi.Client/Http/IRestClient.cs
@@ -7,15 +7,14 @@ namespace ZendeskApi.Client.Http
     public interface IRestClient
     {
         Uri BuildUri(string handler, string query = "");
-
+        T Get<T>(Uri requestUri);
         Task<T> GetAsync<T>(Uri requestUri);
-
+        T Post<T>(Uri requestUri, object item = null, string contentType = "application/json");
         T PostFile<T>(Uri requestUri, IHttpPostedFile file);
-
         Task<T> PostAsync<T>(Uri requestUri, object item = null, string contentType = "application/json");
-
+        T Put<T>(Uri requestUri, object item = null, string contentType = "application/json");
         Task<T> PutAsync<T>(Uri requestUri, object item = null, string contentType = "application/json");
-
+        void Delete(Uri requestUri);
         Task DeleteAsync(Uri requestUri);
     }
 }

--- a/src/ZendeskApi.Client/Resources/AssignableGroupsResource.cs
+++ b/src/ZendeskApi.Client/Resources/AssignableGroupsResource.cs
@@ -18,7 +18,9 @@ namespace ZendeskApi.Client.Resources
 
         public ListResponse<Group> GetAll()
         {
-            return GetAllAsync().Result;
+            var requestUri = _client.BuildUri(AssignableGroupUri);
+
+            return _client.Get<GroupListResponse>(requestUri);
         }
 
         public async Task<ListResponse<Group>> GetAllAsync()

--- a/src/ZendeskApi.Client/Resources/AssignableGroupsResource.cs
+++ b/src/ZendeskApi.Client/Resources/AssignableGroupsResource.cs
@@ -27,7 +27,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = _client.BuildUri(AssignableGroupUri);
 
-            return await _client.GetAsync<GroupListResponse>(requestUri).ConfigureAwait(false);
+            return await _client.GetAsync<GroupListResponse>(requestUri);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/AssignableGroupsResource.cs
+++ b/src/ZendeskApi.Client/Resources/AssignableGroupsResource.cs
@@ -27,7 +27,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = _client.BuildUri(AssignableGroupUri);
 
-            return await _client.GetAsync<GroupListResponse>(requestUri);
+            return await _client.GetAsync<GroupListResponse>(requestUri).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/GroupsResource.cs
+++ b/src/ZendeskApi.Client/Resources/GroupsResource.cs
@@ -16,7 +16,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Group> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<GroupResponse>(id);
         }
 
         public async Task<IResponse<Group>> GetAsync(long id)

--- a/src/ZendeskApi.Client/Resources/GroupsResource.cs
+++ b/src/ZendeskApi.Client/Resources/GroupsResource.cs
@@ -21,7 +21,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Group>> GetAsync(long id)
         {
-            return await GetAsync<GroupResponse>(id);
+            return await GetAsync<GroupResponse>(id).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/GroupsResource.cs
+++ b/src/ZendeskApi.Client/Resources/GroupsResource.cs
@@ -21,7 +21,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Group>> GetAsync(long id)
         {
-            return await GetAsync<GroupResponse>(id).ConfigureAwait(false);
+            return await GetAsync<GroupResponse>(id);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/OrganizationMembershipResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationMembershipResource.cs
@@ -26,7 +26,7 @@ namespace ZendeskApi.Client.Resources
         public async Task<IListResponse<OrganizationMembership>> GetAllByOrganizationAsync(long organizationId)
         {
             _resourceUrl = @"/api/v2/organizations/{0}/organization_memberships";
-            return await GetAllAsync<OrganizationMembershipListResponse>(organizationId);
+            return await GetAllAsync<OrganizationMembershipListResponse>(organizationId).ConfigureAwait(false);
         }
 
         public IListResponse<OrganizationMembership> GetAllByUser(long userId)
@@ -36,7 +36,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<OrganizationMembership>> GetAllByUserAsync(long userId)
         {
-            return await GetAllAsync<OrganizationMembershipListResponse>(userId);
+            return await GetAllAsync<OrganizationMembershipListResponse>(userId).ConfigureAwait(false);
         }
 
         public IResponse<OrganizationMembership> Post(OrganizationMembershipRequest request)
@@ -46,7 +46,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<OrganizationMembership>> PostAsync(OrganizationMembershipRequest request)
         {
-            return await PostAsync<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId);
+            return await PostAsync<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId).ConfigureAwait(false);
         }
 
         [Obsolete("GetAll is deprecated, please use GetAllByUser or GetAllByOrganization instead.")]

--- a/src/ZendeskApi.Client/Resources/OrganizationMembershipResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationMembershipResource.cs
@@ -26,7 +26,7 @@ namespace ZendeskApi.Client.Resources
         public async Task<IListResponse<OrganizationMembership>> GetAllByOrganizationAsync(long organizationId)
         {
             _resourceUrl = @"/api/v2/organizations/{0}/organization_memberships";
-            return await GetAllAsync<OrganizationMembershipListResponse>(organizationId).ConfigureAwait(false);
+            return await GetAllAsync<OrganizationMembershipListResponse>(organizationId);
         }
 
         public IListResponse<OrganizationMembership> GetAllByUser(long userId)
@@ -36,7 +36,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<OrganizationMembership>> GetAllByUserAsync(long userId)
         {
-            return await GetAllAsync<OrganizationMembershipListResponse>(userId).ConfigureAwait(false);
+            return await GetAllAsync<OrganizationMembershipListResponse>(userId);
         }
 
         public IResponse<OrganizationMembership> Post(OrganizationMembershipRequest request)
@@ -46,7 +46,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<OrganizationMembership>> PostAsync(OrganizationMembershipRequest request)
         {
-            return await PostAsync<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId).ConfigureAwait(false);
+            return await PostAsync<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId);
         }
 
         [Obsolete("GetAll is deprecated, please use GetAllByUser or GetAllByOrganization instead.")]

--- a/src/ZendeskApi.Client/Resources/OrganizationMembershipResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationMembershipResource.cs
@@ -19,7 +19,8 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<OrganizationMembership> GetAllByOrganization(long organizationId)
         {
-            return GetAllByOrganizationAsync(organizationId).Result;
+            _resourceUrl = @"/api/v2/organizations/{0}/organization_memberships";
+            return GetAll<OrganizationMembershipListResponse>(organizationId);
         }
 
         public async Task<IListResponse<OrganizationMembership>> GetAllByOrganizationAsync(long organizationId)
@@ -30,22 +31,22 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<OrganizationMembership> GetAllByUser(long userId)
         {
-            return GetAllByUserAsync(userId).Result;
+            return GetAll<OrganizationMembershipListResponse>(userId);
         }
 
         public async Task<IListResponse<OrganizationMembership>> GetAllByUserAsync(long userId)
         {
-            return await GetAllAsync<OrganizationMembershipListResponse>(userId);
+            return await GetAllAsync<OrganizationMembershipListResponse>(userId).ConfigureAwait(false);
         }
 
         public IResponse<OrganizationMembership> Post(OrganizationMembershipRequest request)
         {
-            return PostAsync(request).Result;
+            return Post<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId);
         }
 
         public async Task<IResponse<OrganizationMembership>> PostAsync(OrganizationMembershipRequest request)
         {
-            return await PostAsync<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId);
+            return await PostAsync<OrganizationMembershipRequest, OrganizationMembershipResponse>(request, request.Item.UserId).ConfigureAwait(false);
         }
 
         [Obsolete("GetAll is deprecated, please use GetAllByUser or GetAllByOrganization instead.")]

--- a/src/ZendeskApi.Client/Resources/OrganizationResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationResource.cs
@@ -22,7 +22,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Organization>> GetAsync(long id)
         {
-            return await GetAsync<OrganizationResponse>(id);
+            return await GetAsync<OrganizationResponse>(id).ConfigureAwait(false);
         }
 
         public IResponse<Organization> Put(OrganizationRequest request)
@@ -32,7 +32,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Organization>> PutAsync(OrganizationRequest request)
         {
-            return await PutAsync<OrganizationRequest, OrganizationResponse>(request);
+            return await PutAsync<OrganizationRequest, OrganizationResponse>(request).ConfigureAwait(false);
         }
 
         public IResponse<Organization> Post(OrganizationRequest request)
@@ -42,7 +42,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Organization>> PostAsync(OrganizationRequest request)
         {
-            return await PostAsync<OrganizationRequest, OrganizationResponse>(request);
+            return await PostAsync<OrganizationRequest, OrganizationResponse>(request).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/OrganizationResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationResource.cs
@@ -22,7 +22,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Organization>> GetAsync(long id)
         {
-            return await GetAsync<OrganizationResponse>(id).ConfigureAwait(false);
+            return await GetAsync<OrganizationResponse>(id);
         }
 
         public IResponse<Organization> Put(OrganizationRequest request)
@@ -32,7 +32,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Organization>> PutAsync(OrganizationRequest request)
         {
-            return await PutAsync<OrganizationRequest, OrganizationResponse>(request).ConfigureAwait(false);
+            return await PutAsync<OrganizationRequest, OrganizationResponse>(request);
         }
 
         public IResponse<Organization> Post(OrganizationRequest request)
@@ -42,7 +42,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Organization>> PostAsync(OrganizationRequest request)
         {
-            return await PostAsync<OrganizationRequest, OrganizationResponse>(request).ConfigureAwait(false);
+            return await PostAsync<OrganizationRequest, OrganizationResponse>(request);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/OrganizationResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationResource.cs
@@ -17,7 +17,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Organization> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<OrganizationResponse>(id);
         }
 
         public async Task<IResponse<Organization>> GetAsync(long id)
@@ -27,7 +27,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Organization> Put(OrganizationRequest request)
         {
-            return PutAsync(request).Result;
+            return Put<OrganizationRequest, OrganizationResponse>(request);
         }
 
         public async Task<IResponse<Organization>> PutAsync(OrganizationRequest request)
@@ -37,7 +37,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Organization> Post(OrganizationRequest request)
         {
-            return PostAsync(request).Result;
+            return Post<OrganizationRequest, OrganizationResponse>(request);
         }
 
         public async Task<IResponse<Organization>> PostAsync(OrganizationRequest request)

--- a/src/ZendeskApi.Client/Resources/RequestCommentResource.cs
+++ b/src/ZendeskApi.Client/Resources/RequestCommentResource.cs
@@ -16,7 +16,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<TicketComment> Get(long id, long parentId)
         {
-            return GetAsync(id, parentId).Result;
+            return Get<TicketCommentResponse>(id, parentId);
         }
 
         public async Task<IResponse<TicketComment>> GetAsync(long id, long parentId)
@@ -26,7 +26,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<TicketComment> GetAll(long parentId)
         {
-            return GetAllAsync(parentId).Result;
+            return GetAll<TicketCommentListResponse>(parentId);
         }
 
         public async Task<IListResponse<TicketComment>> GetAllAsync(long parentId)

--- a/src/ZendeskApi.Client/Resources/RequestCommentResource.cs
+++ b/src/ZendeskApi.Client/Resources/RequestCommentResource.cs
@@ -21,7 +21,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<TicketComment>> GetAsync(long id, long parentId)
         {
-            return await GetAsync<TicketCommentResponse>(id, parentId).ConfigureAwait(false);
+            return await GetAsync<TicketCommentResponse>(id, parentId);
         }
 
         public IListResponse<TicketComment> GetAll(long parentId)
@@ -31,7 +31,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketComment>> GetAllAsync(long parentId)
         {
-            return await GetAllAsync<TicketCommentListResponse>(parentId).ConfigureAwait(false);
+            return await GetAllAsync<TicketCommentListResponse>(parentId);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/RequestCommentResource.cs
+++ b/src/ZendeskApi.Client/Resources/RequestCommentResource.cs
@@ -21,7 +21,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<TicketComment>> GetAsync(long id, long parentId)
         {
-            return await GetAsync<TicketCommentResponse>(id, parentId);
+            return await GetAsync<TicketCommentResponse>(id, parentId).ConfigureAwait(false);
         }
 
         public IListResponse<TicketComment> GetAll(long parentId)
@@ -31,7 +31,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketComment>> GetAllAsync(long parentId)
         {
-            return await GetAllAsync<TicketCommentListResponse>(parentId);
+            return await GetAllAsync<TicketCommentListResponse>(parentId).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/RequestResource.cs
+++ b/src/ZendeskApi.Client/Resources/RequestResource.cs
@@ -23,7 +23,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> GetAsync(long id)
         {
-            return await GetAsync<RequestResponse>(id).ConfigureAwait(false);
+            return await GetAsync<RequestResponse>(id);
         }
 
         public IResponse<Request> Get(IEnumerable<TicketStatus> requestedStatuses)
@@ -33,7 +33,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> GetAsync(IEnumerable<TicketStatus> requestedStatuses)
         {
-            return await GetAsync<RequestResponse>($"status={string.Join(",", requestedStatuses).ToLower()}").ConfigureAwait(false);
+            return await GetAsync<RequestResponse>($"status={string.Join(",", requestedStatuses).ToLower()}");
         }
 
         public IResponse<Request> Put(RequestRequest request)
@@ -43,7 +43,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> PutAsync(RequestRequest request)
         {
-            return await PutAsync<RequestRequest, RequestResponse>(request).ConfigureAwait(false);
+            return await PutAsync<RequestRequest, RequestResponse>(request);
         }
 
         public IResponse<Request> Post(RequestRequest request)
@@ -53,7 +53,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> PostAsync(RequestRequest request)
         {
-            return await PostAsync<RequestRequest, RequestResponse>(request).ConfigureAwait(false);
+            return await PostAsync<RequestRequest, RequestResponse>(request);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/RequestResource.cs
+++ b/src/ZendeskApi.Client/Resources/RequestResource.cs
@@ -23,7 +23,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> GetAsync(long id)
         {
-            return await GetAsync<RequestResponse>(id);
+            return await GetAsync<RequestResponse>(id).ConfigureAwait(false);
         }
 
         public IResponse<Request> Get(IEnumerable<TicketStatus> requestedStatuses)
@@ -33,7 +33,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> GetAsync(IEnumerable<TicketStatus> requestedStatuses)
         {
-            return await GetAsync<RequestResponse>($"status={string.Join(",", requestedStatuses).ToLower()}");
+            return await GetAsync<RequestResponse>($"status={string.Join(",", requestedStatuses).ToLower()}").ConfigureAwait(false);
         }
 
         public IResponse<Request> Put(RequestRequest request)
@@ -43,7 +43,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> PutAsync(RequestRequest request)
         {
-            return await PutAsync<RequestRequest, RequestResponse>(request);
+            return await PutAsync<RequestRequest, RequestResponse>(request).ConfigureAwait(false);
         }
 
         public IResponse<Request> Post(RequestRequest request)
@@ -53,7 +53,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Request>> PostAsync(RequestRequest request)
         {
-            return await PostAsync<RequestRequest, RequestResponse>(request);
+            return await PostAsync<RequestRequest, RequestResponse>(request).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/RequestResource.cs
+++ b/src/ZendeskApi.Client/Resources/RequestResource.cs
@@ -18,7 +18,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Request> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<RequestResponse>(id);
         }
 
         public async Task<IResponse<Request>> GetAsync(long id)
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Request> Get(IEnumerable<TicketStatus> requestedStatuses)
         {
-            return GetAsync(requestedStatuses).Result;
+            return Get<RequestResponse>($"status={string.Join(",", requestedStatuses).ToLower()}");
         }
 
         public async Task<IResponse<Request>> GetAsync(IEnumerable<TicketStatus> requestedStatuses)
@@ -38,7 +38,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Request> Put(RequestRequest request)
         {
-            return PutAsync(request).Result;
+            return Put<RequestRequest, RequestResponse>(request);
         }
 
         public async Task<IResponse<Request>> PutAsync(RequestRequest request)
@@ -48,7 +48,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Request> Post(RequestRequest request)
         {
-            return PostAsync(request).Result;
+            return Post<RequestRequest, RequestResponse>(request);
         }
 
         public async Task<IResponse<Request>> PostAsync(RequestRequest request)

--- a/src/ZendeskApi.Client/Resources/SatisfactionRatingResource.cs
+++ b/src/ZendeskApi.Client/Resources/SatisfactionRatingResource.cs
@@ -18,7 +18,9 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<SatisfactionRating> Get(long id)
         {
-            return GetAsync(id).Result;
+            _resourceUrl = "/api/v2/satisfaction_ratings";
+
+            return Get<SatisfactionRatingResponse>(id);
         }
 
         public async Task<IResponse<SatisfactionRating>> GetAsync(long id)
@@ -30,7 +32,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<SatisfactionRating> Post(SatisfactionRatingRequest request, long ticketId)
         {
-            return PostAsync(request, ticketId).Result;
+            return Post<SatisfactionRatingRequest, SatisfactionRatingResponse>(request, ticketId);
         }
 
         public async Task<IResponse<SatisfactionRating>> PostAsync(SatisfactionRatingRequest request, long ticketId)

--- a/src/ZendeskApi.Client/Resources/SatisfactionRatingResource.cs
+++ b/src/ZendeskApi.Client/Resources/SatisfactionRatingResource.cs
@@ -27,7 +27,7 @@ namespace ZendeskApi.Client.Resources
         {
             _resourceUrl = "/api/v2/satisfaction_ratings";
 
-            return await GetAsync<SatisfactionRatingResponse>(id);
+            return await GetAsync<SatisfactionRatingResponse>(id).ConfigureAwait(false);
         }
 
         public IResponse<SatisfactionRating> Post(SatisfactionRatingRequest request, long ticketId)
@@ -37,7 +37,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<SatisfactionRating>> PostAsync(SatisfactionRatingRequest request, long ticketId)
         {
-            return await PostAsync<SatisfactionRatingRequest, SatisfactionRatingResponse>(request, ticketId);
+            return await PostAsync<SatisfactionRatingRequest, SatisfactionRatingResponse>(request, ticketId).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/SatisfactionRatingResource.cs
+++ b/src/ZendeskApi.Client/Resources/SatisfactionRatingResource.cs
@@ -27,7 +27,7 @@ namespace ZendeskApi.Client.Resources
         {
             _resourceUrl = "/api/v2/satisfaction_ratings";
 
-            return await GetAsync<SatisfactionRatingResponse>(id).ConfigureAwait(false);
+            return await GetAsync<SatisfactionRatingResponse>(id);
         }
 
         public IResponse<SatisfactionRating> Post(SatisfactionRatingRequest request, long ticketId)
@@ -37,7 +37,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<SatisfactionRating>> PostAsync(SatisfactionRatingRequest request, long ticketId)
         {
-            return await PostAsync<SatisfactionRatingRequest, SatisfactionRatingResponse>(request, ticketId).ConfigureAwait(false);
+            return await PostAsync<SatisfactionRatingRequest, SatisfactionRatingResponse>(request, ticketId);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/SearchResource.cs
+++ b/src/ZendeskApi.Client/Resources/SearchResource.cs
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = _client.BuildUri(SearchUri, zendeskQuery.BuildQuery());
 
-            return await _client.GetAsync<ListResponse<T>>(requestUri);
+            return await _client.GetAsync<ListResponse<T>>(requestUri).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/SearchResource.cs
+++ b/src/ZendeskApi.Client/Resources/SearchResource.cs
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = _client.BuildUri(SearchUri, zendeskQuery.BuildQuery());
 
-            return await _client.GetAsync<ListResponse<T>>(requestUri).ConfigureAwait(false);
+            return await _client.GetAsync<ListResponse<T>>(requestUri);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/SearchResource.cs
+++ b/src/ZendeskApi.Client/Resources/SearchResource.cs
@@ -19,14 +19,16 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<T> Find<T>(IZendeskQuery<T> zendeskQuery) where T : IZendeskEntity
         {
-            return FindAsync(zendeskQuery).Result;
+            var requestUri = _client.BuildUri(SearchUri, zendeskQuery.BuildQuery());
+
+            return _client.Get<ListResponse<T>>(requestUri);
         }
 
         public async Task<IListResponse<T>> FindAsync<T>(IZendeskQuery<T> zendeskQuery) where T : IZendeskEntity
         {
             var requestUri = _client.BuildUri(SearchUri, zendeskQuery.BuildQuery());
 
-            return await _client.GetAsync<ListResponse<T>>(requestUri);
+            return await _client.GetAsync<ListResponse<T>>(requestUri).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketCommentResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketCommentResource.cs
@@ -21,7 +21,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketComment>> GetAllAsync(long parentId)
         {
-            return await GetAllAsync<TicketCommentListResponse>(parentId);
+            return await GetAllAsync<TicketCommentListResponse>(parentId).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketCommentResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketCommentResource.cs
@@ -16,7 +16,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<TicketComment> GetAll(long parentId)
         {
-            return GetAllAsync(parentId).Result;
+            return GetAll<TicketCommentListResponse>(parentId);
         }
 
         public async Task<IListResponse<TicketComment>> GetAllAsync(long parentId)

--- a/src/ZendeskApi.Client/Resources/TicketCommentResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketCommentResource.cs
@@ -21,7 +21,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketComment>> GetAllAsync(long parentId)
         {
-            return await GetAllAsync<TicketCommentListResponse>(parentId).ConfigureAwait(false);
+            return await GetAllAsync<TicketCommentListResponse>(parentId);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketFieldResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFieldResource.cs
@@ -20,7 +20,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<TicketField>> GetAsync(long id)
         {
-            return await GetAsync<TicketFieldResponse>(id).ConfigureAwait(false);
+            return await GetAsync<TicketFieldResponse>(id);
         }
 
         public IListResponse<TicketField> GetAll()
@@ -30,7 +30,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketField>> GetAllAsync()
         {
-            return await GetAllAsync<TicketFieldListResponse>().ConfigureAwait(false);
+            return await GetAllAsync<TicketFieldListResponse>();
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketFieldResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFieldResource.cs
@@ -15,7 +15,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<TicketField> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<TicketFieldResponse>(id);
         }
 
         public async Task<IResponse<TicketField>> GetAsync(long id)
@@ -25,7 +25,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<TicketField> GetAll()
         {
-            return GetAllAsync().Result;
+            return GetAll<TicketFieldListResponse>();
         }
 
         public async Task<IListResponse<TicketField>> GetAllAsync()

--- a/src/ZendeskApi.Client/Resources/TicketFieldResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFieldResource.cs
@@ -20,7 +20,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<TicketField>> GetAsync(long id)
         {
-            return await GetAsync<TicketFieldResponse>(id);
+            return await GetAsync<TicketFieldResponse>(id).ConfigureAwait(false);
         }
 
         public IListResponse<TicketField> GetAll()
@@ -30,7 +30,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketField>> GetAllAsync()
         {
-            return await GetAllAsync<TicketFieldListResponse>();
+            return await GetAllAsync<TicketFieldListResponse>().ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketFormResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFormResource.cs
@@ -20,7 +20,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<TicketForm>> GetAsync(long id)
         {
-            return await GetAsync<TicketFormResponse>(id);
+            return await GetAsync<TicketFormResponse>(id).ConfigureAwait(false);
         }
 
         public IListResponse<TicketForm> GetAll()
@@ -30,7 +30,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketForm>> GetAllAsync()
         {
-            return await GetAllAsync<TicketFormListResponse>();
+            return await GetAllAsync<TicketFormListResponse>().ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketFormResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFormResource.cs
@@ -20,7 +20,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<TicketForm>> GetAsync(long id)
         {
-            return await GetAsync<TicketFormResponse>(id).ConfigureAwait(false);
+            return await GetAsync<TicketFormResponse>(id);
         }
 
         public IListResponse<TicketForm> GetAll()
@@ -30,7 +30,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<TicketForm>> GetAllAsync()
         {
-            return await GetAllAsync<TicketFormListResponse>().ConfigureAwait(false);
+            return await GetAllAsync<TicketFormListResponse>();
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketFormResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFormResource.cs
@@ -15,7 +15,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<TicketForm> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<TicketFormResponse>(id);
         }
 
         public async Task<IResponse<TicketForm>> GetAsync(long id)
@@ -25,7 +25,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<TicketForm> GetAll()
         {
-            return GetAllAsync().Result;
+            return GetAll<TicketFormListResponse>();
         }
 
         public async Task<IListResponse<TicketForm>> GetAllAsync()

--- a/src/ZendeskApi.Client/Resources/TicketResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketResource.cs
@@ -23,7 +23,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Ticket>> GetAsync(long id)
         {
-            return await GetAsync<TicketResponse>(id).ConfigureAwait(false);
+            return await GetAsync<TicketResponse>(id);
         }
 
         public IListResponse<Ticket> GetAll(List<long> ids)
@@ -33,7 +33,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<Ticket>> GetAllAsync(List<long> ids)
         {
-            return await GetAllAsync<TicketListResponse>(ids).ConfigureAwait(false);
+            return await GetAllAsync<TicketListResponse>(ids);
         }
 
         public IResponse<Ticket> Put(TicketRequest request)
@@ -43,7 +43,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Ticket>> PutAsync(TicketRequest request)
         {
-            return await PutAsync<TicketRequest, TicketResponse>(request).ConfigureAwait(false);
+            return await PutAsync<TicketRequest, TicketResponse>(request);
         }
 
         public IResponse<Ticket> Post(TicketRequest request)
@@ -53,7 +53,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Ticket>> PostAsync(TicketRequest request)
         {
-            return await PostAsync<TicketRequest, TicketResponse>(request).ConfigureAwait(false);
+            return await PostAsync<TicketRequest, TicketResponse>(request);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketResource.cs
@@ -23,7 +23,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Ticket>> GetAsync(long id)
         {
-            return await GetAsync<TicketResponse>(id);
+            return await GetAsync<TicketResponse>(id).ConfigureAwait(false);
         }
 
         public IListResponse<Ticket> GetAll(List<long> ids)
@@ -33,7 +33,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<Ticket>> GetAllAsync(List<long> ids)
         {
-            return await GetAllAsync<TicketListResponse>(ids);
+            return await GetAllAsync<TicketListResponse>(ids).ConfigureAwait(false);
         }
 
         public IResponse<Ticket> Put(TicketRequest request)
@@ -43,7 +43,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Ticket>> PutAsync(TicketRequest request)
         {
-            return await PutAsync<TicketRequest, TicketResponse>(request);
+            return await PutAsync<TicketRequest, TicketResponse>(request).ConfigureAwait(false);
         }
 
         public IResponse<Ticket> Post(TicketRequest request)
@@ -53,7 +53,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Ticket>> PostAsync(TicketRequest request)
         {
-            return await PostAsync<TicketRequest, TicketResponse>(request);
+            return await PostAsync<TicketRequest, TicketResponse>(request).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/TicketResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketResource.cs
@@ -18,7 +18,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Ticket> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<TicketResponse>(id);
         }
 
         public async Task<IResponse<Ticket>> GetAsync(long id)
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<Ticket> GetAll(List<long> ids)
         {
-            return GetAllAsync(ids).Result;
+            return GetAll<TicketListResponse>(ids);
         }
 
         public async Task<IListResponse<Ticket>> GetAllAsync(List<long> ids)
@@ -38,7 +38,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Ticket> Put(TicketRequest request)
         {
-            return PutAsync(request).Result;
+            return Put<TicketRequest, TicketResponse>(request);
         }
 
         public async Task<IResponse<Ticket>> PutAsync(TicketRequest request)
@@ -48,7 +48,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Ticket> Post(TicketRequest request)
         {
-            return PostAsync(request).Result;
+            return Post<TicketRequest, TicketResponse>(request);
         }
 
         public async Task<IResponse<Ticket>> PostAsync(TicketRequest request)

--- a/src/ZendeskApi.Client/Resources/UploadResource.cs
+++ b/src/ZendeskApi.Client/Resources/UploadResource.cs
@@ -22,7 +22,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Upload>> GetAsync(long id)
         {
-            return await GetAsync<UploadResponse>(id);
+            return await GetAsync<UploadResponse>(id).ConfigureAwait(false);
         }
 
         public IResponse<Upload> Post(UploadRequest request)

--- a/src/ZendeskApi.Client/Resources/UploadResource.cs
+++ b/src/ZendeskApi.Client/Resources/UploadResource.cs
@@ -22,7 +22,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<Upload>> GetAsync(long id)
         {
-            return await GetAsync<UploadResponse>(id).ConfigureAwait(false);
+            return await GetAsync<UploadResponse>(id);
         }
 
         public IResponse<Upload> Post(UploadRequest request)

--- a/src/ZendeskApi.Client/Resources/UploadResource.cs
+++ b/src/ZendeskApi.Client/Resources/UploadResource.cs
@@ -17,7 +17,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<Upload> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<UploadResponse>(id);
         }
 
         public async Task<IResponse<Upload>> GetAsync(long id)

--- a/src/ZendeskApi.Client/Resources/UserIdentityResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserIdentityResource.cs
@@ -17,7 +17,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<UserIdentity> GetAll(long id)
         {
-            return GetAllAsync(id).Result;
+            return GetAll<UserIdentityListResponse>(id);
         }
 
         public async Task<IListResponse<UserIdentity>> GetAllAsync(long id)
@@ -27,7 +27,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<UserIdentity> Post(UserIdentityRequest request)
         {
-            return PostAsync(request).Result;
+            return Post<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId);
         }
 
         public async Task<IResponse<UserIdentity>> PostAsync(UserIdentityRequest request)
@@ -37,7 +37,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<UserIdentity> Put(UserIdentityRequest request)
         {
-            return PutAsync(request).Result;
+            return Put<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId);
         }
 
         public async Task<IResponse<UserIdentity>> PutAsync(UserIdentityRequest request)
@@ -47,7 +47,7 @@ namespace ZendeskApi.Client.Resources
 
         public void Delete(long id, long parentId)
         {
-            DeleteAsync(id, parentId).Wait();
+            base.Delete(id, parentId);
         }
 
         public async Task DeleteAsync(long id, long parentId)

--- a/src/ZendeskApi.Client/Resources/UserIdentityResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserIdentityResource.cs
@@ -22,7 +22,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<UserIdentity>> GetAllAsync(long id)
         {
-            return await GetAllAsync<UserIdentityListResponse>(id);
+            return await GetAllAsync<UserIdentityListResponse>(id).ConfigureAwait(false);
         }
 
         public IResponse<UserIdentity> Post(UserIdentityRequest request)
@@ -32,7 +32,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<UserIdentity>> PostAsync(UserIdentityRequest request)
         {
-            return await PostAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId);
+            return await PostAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId).ConfigureAwait(false);
         }
 
         public IResponse<UserIdentity> Put(UserIdentityRequest request)
@@ -42,7 +42,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<UserIdentity>> PutAsync(UserIdentityRequest request)
         {
-            return await PutAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId);
+            return await PutAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId).ConfigureAwait(false);
         }
 
         public void Delete(long id, long parentId)
@@ -52,7 +52,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task DeleteAsync(long id, long parentId)
         {
-            await base.DeleteAsync(id, parentId);
+            await base.DeleteAsync(id, parentId).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/UserIdentityResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserIdentityResource.cs
@@ -22,7 +22,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<UserIdentity>> GetAllAsync(long id)
         {
-            return await GetAllAsync<UserIdentityListResponse>(id).ConfigureAwait(false);
+            return await GetAllAsync<UserIdentityListResponse>(id);
         }
 
         public IResponse<UserIdentity> Post(UserIdentityRequest request)
@@ -32,7 +32,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<UserIdentity>> PostAsync(UserIdentityRequest request)
         {
-            return await PostAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId).ConfigureAwait(false);
+            return await PostAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId);
         }
 
         public IResponse<UserIdentity> Put(UserIdentityRequest request)
@@ -42,7 +42,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<UserIdentity>> PutAsync(UserIdentityRequest request)
         {
-            return await PutAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId).ConfigureAwait(false);
+            return await PutAsync<UserIdentityRequest, UserIdentityResponse>(request, request.Item.UserId);
         }
 
         public void Delete(long id, long parentId)
@@ -52,7 +52,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task DeleteAsync(long id, long parentId)
         {
-            await base.DeleteAsync(id, parentId).ConfigureAwait(false);
+            await base.DeleteAsync(id, parentId);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/UserResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserResource.cs
@@ -23,7 +23,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<User>> GetAsync(long id)
         {
-            return await GetAsync<UserResponse>(id).ConfigureAwait(false);
+            return await GetAsync<UserResponse>(id);
         }
 
         public IListResponse<User> GetAll(List<long> ids)
@@ -33,7 +33,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<User>> GetAllAsync(List<long> ids)
         {
-            return await GetAllAsync<UserListResponse>(ids).ConfigureAwait(false);
+            return await GetAllAsync<UserListResponse>(ids);
         }
 
         public IResponse<User> Post(UserRequest request)
@@ -43,7 +43,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<User>> PostAsync(UserRequest request)
         {
-            return await PostAsync<UserRequest, UserResponse>(request).ConfigureAwait(false);
+            return await PostAsync<UserRequest, UserResponse>(request);
         }
 
         public IResponse<User> Put(UserRequest request)
@@ -53,7 +53,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<User>> PutAsync(UserRequest request)
         {
-            return await PutAsync<UserRequest, UserResponse>(request).ConfigureAwait(false);
+            return await PutAsync<UserRequest, UserResponse>(request);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/UserResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserResource.cs
@@ -18,7 +18,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<User> Get(long id)
         {
-            return GetAsync(id).Result;
+            return Get<UserResponse>(id);
         }
 
         public async Task<IResponse<User>> GetAsync(long id)
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
 
         public IListResponse<User> GetAll(List<long> ids)
         {
-            return GetAllAsync(ids).Result;
+            return GetAll<UserListResponse>(ids);
         }
 
         public async Task<IListResponse<User>> GetAllAsync(List<long> ids)
@@ -38,7 +38,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<User> Post(UserRequest request)
         {
-            return PostAsync(request).Result;
+            return Post<UserRequest, UserResponse>(request);
         }
 
         public async Task<IResponse<User>> PostAsync(UserRequest request)
@@ -48,7 +48,7 @@ namespace ZendeskApi.Client.Resources
 
         public IResponse<User> Put(UserRequest request)
         {
-            return PutAsync(request).Result;
+            return Put<UserRequest, UserResponse>(request);
         }
 
         public async Task<IResponse<User>> PutAsync(UserRequest request)

--- a/src/ZendeskApi.Client/Resources/UserResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserResource.cs
@@ -23,7 +23,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<User>> GetAsync(long id)
         {
-            return await GetAsync<UserResponse>(id);
+            return await GetAsync<UserResponse>(id).ConfigureAwait(false);
         }
 
         public IListResponse<User> GetAll(List<long> ids)
@@ -33,7 +33,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IListResponse<User>> GetAllAsync(List<long> ids)
         {
-            return await GetAllAsync<UserListResponse>(ids);
+            return await GetAllAsync<UserListResponse>(ids).ConfigureAwait(false);
         }
 
         public IResponse<User> Post(UserRequest request)
@@ -43,7 +43,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<User>> PostAsync(UserRequest request)
         {
-            return await PostAsync<UserRequest, UserResponse>(request);
+            return await PostAsync<UserRequest, UserResponse>(request).ConfigureAwait(false);
         }
 
         public IResponse<User> Put(UserRequest request)
@@ -53,7 +53,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<IResponse<User>> PutAsync(UserRequest request)
         {
-            return await PutAsync<UserRequest, UserResponse>(request);
+            return await PutAsync<UserRequest, UserResponse>(request).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/ZendeskResource.cs
+++ b/src/ZendeskApi.Client/Resources/ZendeskResource.cs
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{ResourceUri}/{id}");
 
-            return await Client.GetAsync<TResponse>(requestUri);
+            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
         }
 
         protected IResponse<T> Get<TResponse>(string query) where TResponse : IResponse<T>
@@ -42,7 +42,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri(ResourceUri, query);
 
-            return await Client.GetAsync<TResponse>(requestUri);
+            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
         }
 
         protected IResponse<T> Get<TResponse>(long id, long parentId) where TResponse : IResponse<T>
@@ -56,7 +56,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{string.Format(ResourceUri, parentId)}/{id}");
 
-            return await Client.GetAsync<TResponse>(requestUri);
+            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
         }
 
         protected TResponse GetAll<TResponse>(IEnumerable<long> ids) where TResponse : IListResponse<T>
@@ -70,7 +70,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{ResourceUri}/{ShowMany}", $"ids={ZendeskFormatter.ToCsv(ids)}");
 
-            return await Client.GetAsync<TResponse>(requestUri);
+            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
         }
 
         protected TResponse GetAll<TResponse>(long parentId) where TResponse : IListResponse<T>
@@ -84,7 +84,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri(string.Format(ResourceUri,parentId));
 
-            return await Client.GetAsync<TResponse>(requestUri);
+            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
         }
 
         protected TResponse GetAll<TResponse>() where TResponse : IListResponse<T>
@@ -98,7 +98,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri(string.Format(ResourceUri));
 
-            return await Client.GetAsync<TResponse>(requestUri);
+            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
         }
 
         protected IResponse<T> Put<TRequest, TResponse>(TRequest request)
@@ -112,7 +112,7 @@ namespace ZendeskApi.Client.Resources
             where TRequest : IRequest<T>
             where TResponse : IResponse<T>
         {
-            return await PutAsync<TRequest, TResponse>(request, null);
+            return await PutAsync<TRequest, TResponse>(request, null).ConfigureAwait(false);
         }
 
         protected IResponse<T> Put<TRequest, TResponse>(TRequest request, long? parentId)
@@ -138,7 +138,7 @@ namespace ZendeskApi.Client.Resources
             var resourceUri = parentId == null ? ResourceUri : string.Format(ResourceUri, parentId);
             var requestUri = Client.BuildUri($"{resourceUri}/{request.Item.Id}");
 
-            return await Client.PutAsync<TResponse>(requestUri, request);
+            return await Client.PutAsync<TResponse>(requestUri, request).ConfigureAwait(false);
         }
 
         protected TResponse Post<TRequest, TResponse>(TRequest request) 
@@ -152,7 +152,7 @@ namespace ZendeskApi.Client.Resources
             where TRequest : IRequest<T>
             where TResponse : IResponse<T>
         {
-            return await PostAsync<TRequest, TResponse>(request, null);
+            return await PostAsync<TRequest, TResponse>(request, null).ConfigureAwait(false);
         }
 
         protected TResponse Post<TRequest, TResponse>(TRequest request, long? parentId) 
@@ -172,7 +172,7 @@ namespace ZendeskApi.Client.Resources
             var resourceUri = parentId == null ? ResourceUri : string.Format(ResourceUri, parentId);
             var requestUri = Client.BuildUri(resourceUri);
 
-            return await Client.PostAsync<TResponse>(requestUri, request);
+            return await Client.PostAsync<TResponse>(requestUri, request).ConfigureAwait(false);
         }
 
         public void Delete(long id)
@@ -182,7 +182,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task DeleteAsync(long id)
         {
-            await DeleteAsync(id, null);
+            await DeleteAsync(id, null).ConfigureAwait(false);
         }
 
         public void Delete(string token)
@@ -196,7 +196,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{ResourceUri}/{token}");
 
-            await Client.DeleteAsync(requestUri);
+            await Client.DeleteAsync(requestUri).ConfigureAwait(false);
         }
 
         public void Delete(long id, long? parentId)
@@ -218,7 +218,7 @@ namespace ZendeskApi.Client.Resources
             var resourceUri = parentId == null ? ResourceUri : string.Format(ResourceUri, parentId);
             var requestUri = Client.BuildUri($"{resourceUri}/{id}");
 
-            await Client.DeleteAsync(requestUri);
+            await Client.DeleteAsync(requestUri).ConfigureAwait(false);
         }
     }
 }

--- a/src/ZendeskApi.Client/Resources/ZendeskResource.cs
+++ b/src/ZendeskApi.Client/Resources/ZendeskResource.cs
@@ -28,7 +28,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{ResourceUri}/{id}");
 
-            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
+            return await Client.GetAsync<TResponse>(requestUri);
         }
 
         protected IResponse<T> Get<TResponse>(string query) where TResponse : IResponse<T>
@@ -42,7 +42,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri(ResourceUri, query);
 
-            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
+            return await Client.GetAsync<TResponse>(requestUri);
         }
 
         protected IResponse<T> Get<TResponse>(long id, long parentId) where TResponse : IResponse<T>
@@ -56,7 +56,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{string.Format(ResourceUri, parentId)}/{id}");
 
-            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
+            return await Client.GetAsync<TResponse>(requestUri);
         }
 
         protected TResponse GetAll<TResponse>(IEnumerable<long> ids) where TResponse : IListResponse<T>
@@ -70,7 +70,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{ResourceUri}/{ShowMany}", $"ids={ZendeskFormatter.ToCsv(ids)}");
 
-            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
+            return await Client.GetAsync<TResponse>(requestUri);
         }
 
         protected TResponse GetAll<TResponse>(long parentId) where TResponse : IListResponse<T>
@@ -84,7 +84,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri(string.Format(ResourceUri,parentId));
 
-            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
+            return await Client.GetAsync<TResponse>(requestUri);
         }
 
         protected TResponse GetAll<TResponse>() where TResponse : IListResponse<T>
@@ -98,7 +98,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri(string.Format(ResourceUri));
 
-            return await Client.GetAsync<TResponse>(requestUri).ConfigureAwait(false);
+            return await Client.GetAsync<TResponse>(requestUri);
         }
 
         protected IResponse<T> Put<TRequest, TResponse>(TRequest request)
@@ -112,7 +112,7 @@ namespace ZendeskApi.Client.Resources
             where TRequest : IRequest<T>
             where TResponse : IResponse<T>
         {
-            return await PutAsync<TRequest, TResponse>(request, null).ConfigureAwait(false);
+            return await PutAsync<TRequest, TResponse>(request, null);
         }
 
         protected IResponse<T> Put<TRequest, TResponse>(TRequest request, long? parentId)
@@ -138,7 +138,7 @@ namespace ZendeskApi.Client.Resources
             var resourceUri = parentId == null ? ResourceUri : string.Format(ResourceUri, parentId);
             var requestUri = Client.BuildUri($"{resourceUri}/{request.Item.Id}");
 
-            return await Client.PutAsync<TResponse>(requestUri, request).ConfigureAwait(false);
+            return await Client.PutAsync<TResponse>(requestUri, request);
         }
 
         protected TResponse Post<TRequest, TResponse>(TRequest request) 
@@ -152,7 +152,7 @@ namespace ZendeskApi.Client.Resources
             where TRequest : IRequest<T>
             where TResponse : IResponse<T>
         {
-            return await PostAsync<TRequest, TResponse>(request, null).ConfigureAwait(false);
+            return await PostAsync<TRequest, TResponse>(request, null);
         }
 
         protected TResponse Post<TRequest, TResponse>(TRequest request, long? parentId) 
@@ -172,7 +172,7 @@ namespace ZendeskApi.Client.Resources
             var resourceUri = parentId == null ? ResourceUri : string.Format(ResourceUri, parentId);
             var requestUri = Client.BuildUri(resourceUri);
 
-            return await Client.PostAsync<TResponse>(requestUri, request).ConfigureAwait(false);
+            return await Client.PostAsync<TResponse>(requestUri, request);
         }
 
         public void Delete(long id)
@@ -182,7 +182,7 @@ namespace ZendeskApi.Client.Resources
 
         public async Task DeleteAsync(long id)
         {
-            await DeleteAsync(id, null).ConfigureAwait(false);
+            await DeleteAsync(id, null);
         }
 
         public void Delete(string token)
@@ -196,7 +196,7 @@ namespace ZendeskApi.Client.Resources
         {
             var requestUri = Client.BuildUri($"{ResourceUri}/{token}");
 
-            await Client.DeleteAsync(requestUri).ConfigureAwait(false);
+            await Client.DeleteAsync(requestUri);
         }
 
         public void Delete(long id, long? parentId)
@@ -218,7 +218,7 @@ namespace ZendeskApi.Client.Resources
             var resourceUri = parentId == null ? ResourceUri : string.Format(ResourceUri, parentId);
             var requestUri = Client.BuildUri($"{resourceUri}/{id}");
 
-            await Client.DeleteAsync(requestUri).ConfigureAwait(false);
+            await Client.DeleteAsync(requestUri);
         }
     }
 }

--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -40,6 +40,8 @@
     <!--If configuration is not provided, default to Debug build-->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <OutputPath>bin\$(Configuration)\$(NugetFrameworkVersion)\</OutputPath>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Choose>
     <When Condition="$(Configuration.Contains('Debug'))">
@@ -146,12 +148,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup Condition="$(Configuration.Contains('40'))">
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Threading.Tasks.dll</HintPath>
-    </Reference>
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
@@ -174,5 +170,12 @@
   <Target Name="BuildAll" DependsOnTargets="configurations" Inputs="@(Configuration)">
     <Message Text="Building: (%(Configuration.Identity))" />
     <MSBuild ContinueOnError="false" Properties="Configuration=%(Configuration.Identity)" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
 </Project>

--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -153,6 +153,16 @@
   <ItemGroup>
     <Folder Include="lib\" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll">
+      <Link>System.Runtime.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll">
+      <Link>System.Threading.Tasks.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -153,16 +153,6 @@
   <ItemGroup>
     <Folder Include="lib\" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll">
-      <Link>System.Runtime.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll">
-      <Link>System.Threading.Tasks.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/ZendeskApi.Client/ZendeskApi.Client.nuspec
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.nuspec
@@ -10,17 +10,10 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>API Client for use with Zendesk</description>
         <dependencies>
-			<group targetFramework="net45">
-				<dependency id="Newtonsoft.Json" version="6.0.8" />
-			</group>
-			<group targetFramework="net40">
-        <dependency id="Newtonsoft.Json" version="6.0.8" />
-				<dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-			</group>
+				  <dependency id="Newtonsoft.Json" version="6.0.8" />
         </dependencies>
     </metadata>
   <files>
     <file src="bin\Release\net45\ZendeskApi*.*" target="lib\net45" />
-    <file src="bin\Release40\net40\ZendeskApi*.*" target="lib\net40" />
   </files>
 </package>

--- a/src/ZendeskApi.Client/packages.config
+++ b/src/ZendeskApi.Client/packages.config
@@ -4,5 +4,4 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Client/packages.config
+++ b/src/ZendeskApi.Client/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Client/packages.config
+++ b/src/ZendeskApi.Client/packages.config
@@ -4,4 +4,5 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Contracts.Tests/ZendeskApi.Contracts.Tests.csproj
+++ b/src/ZendeskApi.Contracts.Tests/ZendeskApi.Contracts.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NugetFrameworkVersion>net45</NugetFrameworkVersion>
@@ -55,10 +54,14 @@
       </PropertyGroup>
     </When>
   </Choose>
-
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\$(NugetFrameworkVersion)\Newtonsoft.Json.dll</HintPath>
@@ -92,7 +95,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name = "Clean">
-        <RemoveDir Directories="bin" />
+  <Target Name="Clean">
+    <RemoveDir Directories="bin" />
   </Target>
 </Project>

--- a/src/ZendeskApi.Contracts.Tests/packages.config
+++ b/src/ZendeskApi.Contracts.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />

--- a/src/ZendeskApi.Contracts.Tests/packages.config
+++ b/src/ZendeskApi.Contracts.Tests/packages.config
@@ -4,5 +4,4 @@
   <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Contracts.Tests/packages.config
+++ b/src/ZendeskApi.Contracts.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" />
   <package id="NUnit" version="2.6.3" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Contracts/packages.config
+++ b/src/ZendeskApi.Contracts/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/src/ZendeskApi.Contracts/packages.config
+++ b/src/ZendeskApi.Contracts/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8"  />
+  <package id="Newtonsoft.Json" version="6.0.8" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Still to do is create acceptance tests for the async methods.
Going forward, the sync ones should be deprecated.