### PR TITLE
Fix request that needs to be inside a wrapper class

### DIFF
--- a/src/ZendeskApi.Client/Models/Organization.cs
+++ b/src/ZendeskApi.Client/Models/Organization.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi.Client.Converters;
@@ -60,5 +60,12 @@ namespace ZendeskApi.Client.Models
 
         [JsonProperty("result_type")]
         internal string ResultType => "organization";
+    }
+
+    
+    internal class OrganisationWrapper
+    {
+        [JsonProperty("organization")]
+        public Organization Organization { get; set; }
     }
 }

--- a/src/ZendeskApi.Client/Models/UserIdentity.cs
+++ b/src/ZendeskApi.Client/Models/UserIdentity.cs
@@ -37,4 +37,22 @@ namespace ZendeskApi.Client.Models
         public DateTime? UpdatedAt { get; set; }
 
     }
+
+    [JsonObject("identity")]
+    internal class IdentityWrapper
+    {
+        [JsonProperty("identity")]
+        public UserIdentity Identity { get; set; }
+    }
+
+    internal class UserWrapper<T>
+    {
+        [JsonProperty("user")]
+        public T User { get; set; }
+
+        public UserWrapper(T user)
+        {
+            User = user;
+        }
+    }
 }

--- a/src/ZendeskApi.Client/Requests/UserCreateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/UserCreateRequest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi.Client.Models;
 
@@ -99,7 +99,7 @@ namespace ZendeskApi.Client.Requests
         /// The user's role. Possible values are "end-user", "agent", or "admin"
         /// </summary>
         [JsonProperty("role")]
-        public UserRole? Role { get; set; }
+        public string Role { get; set; }
 
         /// <summary>
         /// The user's signature. Only agents and admins can have signatures
@@ -113,6 +113,9 @@ namespace ZendeskApi.Client.Requests
         [JsonProperty("suspended")]
         public bool? Suspended { get; set; }
 
+       [JsonProperty("shared_phone_number")]
+        public bool? SharedPhoneNumber { get; set; }
+
         /// <summary>
         /// The user's tags. Only present if your account has user tagging enabled
         /// </summary>
@@ -123,7 +126,7 @@ namespace ZendeskApi.Client.Requests
         /// Specifies which tickets the user has access to. Possible values are: "organization", "groups", "assigned", "requested", null
         /// </summary>
         [JsonProperty("ticket_restriction")]
-        public TicketRestriction? TicketRestriction { get; set; }
+        public string TicketRestriction { get; set; }
 
         /// <summary>
         /// The user's time zone

--- a/src/ZendeskApi.Client/Requests/UserUpdateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/UserUpdateRequest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi.Client.Models;
 
@@ -98,11 +98,13 @@ namespace ZendeskApi.Client.Requests
         [JsonProperty("restricted_agent")]
         public bool? RestrictedAgent { get; set; }
 
+        [JsonProperty("shared_phone_number")]
+        public bool? SharedPhoneNumber { get; set; }
         /// <summary>
         /// The user's role. Possible values are "end-user", "agent", or "admin"
         /// </summary>
         [JsonProperty("role")]
-        public UserRole? Role { get; set; }
+        public string Role { get; set; }
 
         /// <summary>
         /// The user's signature. Only agents and admins can have signatures
@@ -126,7 +128,7 @@ namespace ZendeskApi.Client.Requests
         /// Specifies which tickets the user has access to. Possible values are: "organization", "groups", "assigned", "requested", null
         /// </summary>
         [JsonProperty("ticket_restriction")]
-        public TicketRestriction? TicketRestriction { get; set; }
+        public string TicketRestriction { get; set; }
 
         /// <summary>
         /// The user's time zone

--- a/src/ZendeskApi.Client/Resources/OrganizationsResource.cs
+++ b/src/ZendeskApi.Client/Resources/OrganizationsResource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -75,7 +75,8 @@ namespace ZendeskApi.Client.Resources
 
                 response.EnsureSuccessStatusCode();
 
-                return await response.Content.ReadAsAsync<Organization>();
+                var org= await response.Content.ReadAsAsync<OrganisationWrapper>();
+                return org.Organization;
             }
         }
 

--- a/src/ZendeskApi.Client/Resources/UserIdentitiesResource.cs
+++ b/src/ZendeskApi.Client/Resources/UserIdentitiesResource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -60,10 +60,14 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<UserIdentity> CreateUserIdentityAsync(UserIdentity identity, long userId)
         {
+            string resourceUriFormat = "api/v2/users/{0}/identities";
             using (_loggerScope(_logger, $"CreateUserIdentityAsync({userId})"))
             using (var client = _apiClient.CreateClient())
             {
-                var response = await client.PostAsJsonAsync(string.Format(ResourceUriFormat, userId), identity).ConfigureAwait(false);
+                var idWrapper = new IdentityWrapper { Identity = identity };
+                var response = await client
+                    .PostAsJsonAsync(string.Format(resourceUriFormat, userId), idWrapper)
+                    .ConfigureAwait(false);
 
                 if (response.StatusCode != System.Net.HttpStatusCode.Created)
                 {
@@ -73,16 +77,22 @@ namespace ZendeskApi.Client.Resources
                         "See: https://developer.zendesk.com/rest_api/docs/core/user_identities#create-identity");
                 }
 
-                return await response.Content.ReadAsAsync<UserIdentity>();
+                var idd = await response.Content.ReadAsAsync<IdentityWrapper>();
+                return idd.Identity;
             }
         }
 
         public async Task<UserIdentity> CreateEndUserIdentityAsync(UserIdentity identity, long endUserId)
         {
+            string resourceUriFormat = "api/v2/users/{0}/identities";
             using (_loggerScope(_logger, $"CreateEndUserIdentityAsync({endUserId})"))
             using (var client = _apiClient.CreateClient())
             {
-                var response = await client.PostAsJsonAsync(string.Format(EndUsersResourceUriFormat, endUserId), identity).ConfigureAwait(false);
+                var idWrapper = new IdentityWrapper { Identity = identity };
+                var response = await client
+                    .PostAsJsonAsync(string.Format(resourceUriFormat, endUserId), idWrapper)
+                    .ConfigureAwait(false);
+
 
                 if (response.StatusCode != System.Net.HttpStatusCode.Created)
                 {
@@ -92,16 +102,21 @@ namespace ZendeskApi.Client.Resources
                         "See: https://developer.zendesk.com/rest_api/docs/core/user_identities#create-identity");
                 }
 
-                return await response.Content.ReadAsAsync<UserIdentity>();
+                var idd = await response.Content.ReadAsAsync<IdentityWrapper>();
+                return idd.Identity;
             }
         }
 
         public async Task<UserIdentity> UpdateAsync(UserIdentity identity)
         {
+            string resourceUriFormat = "api/v2/users/{0}/identities/{1}";
             using (_loggerScope(_logger, $"PutAsync"))
             using (var client = _apiClient.CreateClient())
             {
-                var response = await client.PutAsJsonAsync(string.Format(ResourceUriFormat, identity.UserId), identity).ConfigureAwait(false);
+                var idWrapper = new IdentityWrapper { Identity = identity };
+                var response = await client
+                    .PutAsJsonAsync(string.Format(resourceUriFormat, identity.UserId, identity.Id), idWrapper)
+                    .ConfigureAwait(false);
                 
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
@@ -111,7 +126,8 @@ namespace ZendeskApi.Client.Resources
 
                 response.EnsureSuccessStatusCode();
 
-                return await response.Content.ReadAsAsync<UserIdentity>();
+                var idd = await response.Content.ReadAsAsync<IdentityWrapper>();
+                return idd.Identity;
             }
         }
 

--- a/src/ZendeskApi.Client/Resources/UsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/UsersResource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -204,7 +204,8 @@ namespace ZendeskApi.Client.Resources
                         .Build();
                 }
 
-                return await response.Content.ReadAsAsync<UserResponse>();
+                var userr = await response.Content.ReadAsAsync<UserWrapper<UserResponse>>();
+                return userr.User;
             }
         }
         
@@ -229,7 +230,8 @@ namespace ZendeskApi.Client.Resources
                         .Build();
                 }
 
-                return await response.Content.ReadAsAsync<UserResponse>();
+                var userr = await response.Content.ReadAsAsync<UserWrapper<UserResponse>>();
+                return userr.User;
             }
         }
 
@@ -240,14 +242,13 @@ namespace ZendeskApi.Client.Resources
             {
                 var response = await client.DeleteAsync(userId.ToString()).ConfigureAwait(false);
 
-                if (response.StatusCode != HttpStatusCode.NoContent)
-                {
-                    throw await new ZendeskRequestExceptionBuilder()
-                        .WithResponse(response)
-                        .WithExpectedHttpStatus(HttpStatusCode.NoContent)
-                        .WithHelpDocsLink("core/users#delete-user")
-                        .Build();
-                }
+                if (response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.OK)
+                    return;
+                throw await new ZendeskRequestExceptionBuilder()
+                    .WithResponse(response)
+                    .WithExpectedHttpStatus(HttpStatusCode.NoContent)
+                    .WithHelpDocsLink("core/users#delete-user")
+                    .Build();
             }
         }
     }

--- a/src/ZendeskApi.Client/Responses/UserResponse.cs
+++ b/src/ZendeskApi.Client/Responses/UserResponse.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi.Client.Converters;
@@ -135,7 +135,7 @@ namespace ZendeskApi.Client.Responses
         /// The user's role. Possible values are "end-user", "agent", or "admin"
         /// </summary>
         [JsonProperty("role")]
-        public UserRole Role { get; internal set; }
+        public string Role { get; internal set; }
 
         /// <summary>
         /// If the user is shared from a different Zendesk Support instance. Ticket sharing accounts only
@@ -148,6 +148,10 @@ namespace ZendeskApi.Client.Responses
         /// </summary>
         [JsonProperty("shared_agent")]
         public bool SharedAgent { get; internal set; }
+        
+      
+        [JsonProperty("shared_phone_number")]
+        public bool SharedPhoneNumber { get; internal set; }
 
         /// <summary>
         /// The user's signature. Only agents and admins can have signatures
@@ -171,7 +175,7 @@ namespace ZendeskApi.Client.Responses
         /// Specifies which tickets the user has access to. Possible values are: "organization", "groups", "assigned", "requested", null
         /// </summary>
         [JsonProperty("ticket_restriction")]
-        public TicketRestriction? TicketRestriction { get; internal set; }
+        public string TicketRestriction { get; internal set; }
 
         /// <summary>
         /// The user's time zone


### PR DESCRIPTION
For The following bugs:
For user and UserIdentity
- Added Wrapper classes for UserIdentity and User
- UserIdentities had wrong resourceUriFormat

Following propoerties doesn' work as an enum, they could not be desiralized and modified into a string:
- UserRole
- TicketRestriction

Added properties:
SharedPhoneNumber
