### PR TITLE
Fixed user create, fetch and update

### DIFF
--- a/src/ZendeskApi.Client/Resources/UsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/UsersResource.cs
@@ -121,7 +121,8 @@ namespace ZendeskApi.Client.Resources
                         .Build();
                 }
 
-                return await response.Content.ReadAsAsync<UserResponse>();
+                var result = await response.Content.ReadAsAsync<SingleUserResponse>();
+                return result.UserResponse;
             }
         }
         
@@ -204,7 +205,8 @@ namespace ZendeskApi.Client.Resources
                         .Build();
                 }
 
-                return await response.Content.ReadAsAsync<UserResponse>();
+                var result = await response.Content.ReadAsAsync<SingleUserResponse>();
+                return result.UserResponse;
             }
         }
         
@@ -229,7 +231,8 @@ namespace ZendeskApi.Client.Resources
                         .Build();
                 }
 
-                return await response.Content.ReadAsAsync<UserResponse>();
+                var result = await response.Content.ReadAsAsync<SingleUserResponse>();
+                return result.UserResponse;
             }
         }
 

--- a/src/ZendeskApi.Client/Responses/SingleUserResponse.cs
+++ b/src/ZendeskApi.Client/Responses/SingleUserResponse.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace ZendeskApi.Client.Responses
+{
+    [JsonObject]
+    class SingleUserResponse
+    {
+        [JsonProperty("user")]
+        public UserResponse UserResponse { get; set; }
+    }
+}

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/UsersResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/UsersResourceSampleSite.cs
@@ -69,7 +69,10 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                         var user = state.Users[id];
 
                         resp.StatusCode = (int) HttpStatusCode.OK;
-                        return resp.WriteAsJson(user);
+                        return resp.WriteAsJson(new SingleUserResponse
+                        {
+                            UserResponse = user
+                        });
                     })
                     .MapGet("api/v2/users", (req, resp, routeData) =>
                     {
@@ -137,7 +140,10 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                         state.Users.Add(userNew.Id, userNew);
 
                         resp.StatusCode = (int) HttpStatusCode.Created;
-                        return resp.WriteAsJson(userNew);
+                        return resp.WriteAsJson(new SingleUserResponse
+                        {
+                            UserResponse = userNew
+                        });
                     })
                     .MapPut("api/v2/users/{id}", (req, resp, routeData) =>
                     {
@@ -158,7 +164,10 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                         mapper.Map(user, state.Users[id]);
 
                         resp.StatusCode = (int) HttpStatusCode.Created;
-                        return resp.WriteAsJson(user);
+                        return resp.WriteAsJson(new
+                        {
+                            user
+                        });
                     })
                     .MapDelete("api/v2/users/{id}", (req, resp, routeData) =>
                     {


### PR DESCRIPTION
See: https://developer.zendesk.com/rest_api/docs/core/users#create-user 

The endpoints for getting a single user, creating a user and updating a single user alle returns the user wrapped in a { user: { ... } } object. That's why I added the "SingleUserResponse" object.

I would preferably refactor the "UserResponse" object, but it's used in several other responses, so I didn't want to break anything. I feel like the resource should ideally just return a general "User" object, in the same vein as the organization resource does.