### PR TITLE
Fixed attachment uploading

### DIFF
--- a/src/ZendeskApi.Client/Extensions/HttpRequestExtensions.cs
+++ b/src/ZendeskApi.Client/Extensions/HttpRequestExtensions.cs
@@ -48,18 +48,25 @@ namespace ZendeskApi.Client.Extensions
             return await client.PostAsync(requestUri, content).ConfigureAwait(false);
         }
 
+        /**
+         * See https://developer.zendesk.com/rest_api/docs/core/attachments#upload-files
+         * The api takes binary files without Multipart boundaries
+         */
         public static async Task<HttpResponseMessage> PostAsBinaryAsync(
             this HttpClient client,
             string requestUri,
             Stream inputStream,
             string fileName)
         {
-            using (var content = new MultipartFormDataContent()) 
+            using (var stream = new MemoryStream())
             {
-                content.Add(new StreamContent(inputStream), fileName, fileName);
-                content.Headers.ContentType = new MediaTypeHeaderValue("application/binary");
+                inputStream.CopyTo(stream);
+                using (var content = new ByteArrayContent(stream.ToArray()))
+                {
+                    content.Headers.ContentType = new MediaTypeHeaderValue("application/binary");
 
-                return await client.PostAsync(requestUri, content).ConfigureAwait(false);
+                    return await client.PostAsync(requestUri, content).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/ZendeskApi.Client/Models/Attachment.cs
+++ b/src/ZendeskApi.Client/Models/Attachment.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace ZendeskApi.Client.Models
@@ -25,6 +25,6 @@ namespace ZendeskApi.Client.Models
         public string ContentType { get; set; }
 
         [JsonProperty("size")]
-        public int Size { get; set; }
+        public long Size { get; set; }
     }
 }

--- a/src/ZendeskApi.Client/Resources/AttachmentsResource.cs
+++ b/src/ZendeskApi.Client/Resources/AttachmentsResource.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ZendeskApi.Client.Extensions;
 using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Responses;
 
 namespace ZendeskApi.Client.Resources
 {
@@ -66,7 +67,8 @@ namespace ZendeskApi.Client.Resources
                         "See: https://developer.zendesk.com/rest_api/docs/core/attachments#upload-files");
                 }
 
-                return await response.Content.ReadAsAsync<Upload>();
+                var uploadResponse = await response.Content.ReadAsAsync<UploadResponse>();
+                return uploadResponse.Upload;
             }
         }
 

--- a/src/ZendeskApi.Client/Resources/IAttachmentsResource.cs
+++ b/src/ZendeskApi.Client/Resources/IAttachmentsResource.cs
@@ -1,6 +1,7 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Responses;
 
 namespace ZendeskApi.Client.Resources
 {

--- a/src/ZendeskApi.Client/Responses/UploadResponse.cs
+++ b/src/ZendeskApi.Client/Responses/UploadResponse.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Responses
+{
+    [JsonObject]
+    public class UploadResponse
+    {
+        [JsonProperty("upload")]
+        public Upload Upload { get; set; }
+    }
+}

--- a/test/ZendeskApi.Client.Tests/Responses/UploadResponseTests.cs
+++ b/test/ZendeskApi.Client.Tests/Responses/UploadResponseTests.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using System.Text;
+using Xunit;
+using ZendeskApi.Client.Extensions;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Tests.Responses
+{
+    public class UploadResponseTests
+    {
+        [Fact]
+        public void ShouldDeserializeResponse()
+        {
+            var exampleResponse = @"
+            {
+              ""upload"": {
+                ""token"": ""6jsaDLkjdf3r087uJHFf83"",
+                ""expires_at"": ""2017-09-25T08:47:22Z"",
+                ""attachments"": [
+                  {
+                    ""url"": ""https://kung.fu/api/v2/attachments/123737562314.json"",
+                    ""id"": 123737562314,
+                    ""file_name"": ""crash.log"",
+                    ""content_url"": ""https://kung.fu.com/attachments/token/6jsaDLkjdf3r087uJHFf83/?name=crash.log"",
+                    ""mapped_content_url"": ""https://kung.fu.com/attachments/token/6jsaDLkjdf3r087uJHFf83/?name=crash.log"",
+                    ""content_type"": ""text/plain"",
+                    ""size"": 10,
+                    ""width"": null,
+                    ""height"": null,
+                    ""inline"": false,
+                    ""thumbnails"": []
+                  }
+                ],
+                ""attachment"": {
+                  ""url"": ""https://kung.fu.com/api/v2/attachments/123737562314.json"",
+                  ""id"": 123737562314,
+                  ""file_name"": ""crash.log"",
+                  ""content_url"": ""https://kung.fu.com/attachments/token/6jsaDLkjdf3r087uJHFf83/?name=crash.log"",
+                  ""mapped_content_url"": ""https://kung.fu.com/attachments/token/6jsaDLkjdf3r087uJHFf83/?name=crash.log"",
+                  ""content_type"": ""text/plain"",
+                  ""size"": 10,
+                  ""width"": null,
+                  ""height"": null,
+                  ""inline"": false,
+                  ""thumbnails"": []
+                }
+              }
+            }";
+
+            Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(exampleResponse));
+            UploadResponse response = stream.ReadAs<UploadResponse>();
+
+            Assert.NotNull(response.Upload);
+            Assert.NotNull(response.Upload.Attachment);
+            Assert.Equal("6jsaDLkjdf3r087uJHFf83", response.Upload.Token);
+            Assert.Equal(123737562314L, response.Upload.Attachment.Id);
+        }
+    }
+}


### PR DESCRIPTION
Re-submit of #94 

Fixes #93

Changed the binary upload to not upload with multipart boundaries, now just uploading pure binary content
Fixed tests accordingly
Added UploadResponse as a wrapper for the Upload object, and also added a deserializing test for this, with a real-life example response (I had an issue where the Upload object would not deserialize properly)