### PR TITLE
Added Incremental Export to Users resource

### DIFF
--- a/src/ZendeskApi.Client/Resources/IUsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/IUsersResource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using ZendeskApi.Client.Models;
 using ZendeskApi.Client.Requests;
@@ -18,6 +19,7 @@ namespace ZendeskApi.Client.Resources
 
         #region Get Users
         Task<UserResponse> GetAsync(long userId);
+        Task<IncrementalUsersResponse<UserResponse>> GetIncrementalExport(DateTime startTime);
         #endregion
 
         #region Create Users

--- a/src/ZendeskApi.Client/Responses/IncrementalUsersResponse.cs
+++ b/src/ZendeskApi.Client/Responses/IncrementalUsersResponse.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Responses
+{
+    /// <summary>
+    /// See: https://developer.zendesk.com/rest_api/docs/core/incremental_export#incremental-user-export
+    /// 
+    /// Pagination does not work like other pagination, with incremental
+    /// export there will always be a next_page uri. The way to determine
+    /// wether or not there are more resources is to see if the response
+    /// contains a full list of a 1000 users. If less, then there is no
+    /// newer results.
+    /// </summary>
+    [JsonObject]
+    public class IncrementalUsersResponse<T> : PaginationResponse<T> where T : UserResponse
+    {
+
+        [JsonConstructor]
+        public IncrementalUsersResponse()
+        {
+        }
+
+        /// <summary>
+        /// For testing purposes
+        /// </summary>
+        public IncrementalUsersResponse(long endTime)
+        {
+            _endTime = endTime;
+        }
+
+        [JsonProperty("users")]
+        public IEnumerable<T> Users { get; set; }
+
+        protected override IEnumerable<T> Enumerable => Users;
+
+        [JsonProperty("end_time")]
+        private long _endTime { get; set; }
+
+        [JsonIgnore]
+        public DateTime EndTime => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(_endTime);
+
+        [JsonIgnore]
+        public bool HasMoreResults => Count == 1000;
+    }
+}

--- a/test/ZendeskApi.Client.Tests/Responses/IncrementalUsersResponseTests.cs
+++ b/test/ZendeskApi.Client.Tests/Responses/IncrementalUsersResponseTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+using ZendeskApi.Client.Extensions;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Tests.Responses
+{
+    public class IncrementalUsersResponseTests
+    {
+        [Fact]
+        public void ShouldDeserializeResponse()
+        {
+            var exampleResponse = @"
+            {
+              ""users"": [
+                {
+                  ""id"": 482198789412,
+                  ""url"": ""https://kung.fu/api/v2/users/482198789412.json"",
+                  ""name"": ""Test User Name"",
+                  ""email"": ""test@kung.fu"",
+                  ""created_at"": ""2017-10-05T08:41:59Z"",
+                  ""updated_at"": ""2017-10-06T14:27:20Z"",
+                  ""time_zone"": ""Copenhagen"",
+                  ""phone"": ""+470123456789"",
+                  ""shared_phone_number"": false,
+                  ""photo"": null,
+                  ""locale_id"": 34,
+                  ""locale"": ""no"",
+                  ""organization_id"": 145789215754,
+                  ""role"": ""end-user"",
+                  ""verified"": true,
+                  ""external_id"": ""123456"",
+                  ""tags"": [
+                    ""test""
+                  ],
+                  ""alias"": """",
+                  ""active"": true,
+                  ""shared"": false,
+                  ""shared_agent"": false,
+                  ""last_login_at"": null,
+                  ""two_factor_auth_enabled"": false,
+                  ""signature"": null,
+                  ""details"": """",
+                  ""notes"": """",
+                  ""role_type"": null,
+                  ""custom_role_id"": null,
+                  ""moderator"": false,
+                  ""ticket_restriction"": ""requested"",
+                  ""only_private_comments"": false,
+                  ""restricted_agent"": true,
+                  ""suspended"": false,
+                  ""chat_only"": false,
+                  ""default_group_id"": null,
+                  ""user_fields"": {
+                    ""puzzel_phone_numbers"": null
+                  }
+                }
+              ],
+              ""next_page"": ""https://kung.fu/api/v2/incremental/users?start_time=1507531370"",
+              ""count"": 1,
+              ""end_time"": 1507531370
+            }";
+
+            Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(exampleResponse));
+            IncrementalUsersResponse<UserResponse> response = stream.ReadAs<IncrementalUsersResponse<UserResponse>>();
+
+            Assert.NotNull(response.Users);
+            Assert.Equal(1, response.Users.Count());
+            Assert.Equal(1, response.Count);
+            Assert.False(response.HasMoreResults);
+            Assert.Equal("test@kung.fu", response.Users.First().Email);
+        }
+    }
+}


### PR DESCRIPTION
See: https://developer.zendesk.com/rest_api/docs/core/incremental_export#incremental-user-export

Added new method to the Users resource, as well as tests for resource and deserializing.

Note: pagination is a bit different for incremental exports, so the PaginationResponse will not have a valid pager. That's why it also has a HasMoreResults property, to let the client check for more results using the EndTime property for the next request. Ex:

```csharp
var startTime = DateTime.UtcNow;
IncrementalUsersResponse<UserResponse> response;
do
{
    response = await _client.Users.GetIncrementalExport(startTime);
    startTime = response.EndTime;

    Console.WriteLine($"Found {response.Count} changed users!");

    foreach (var user in response.Users)
    {
        Console.WriteLine($"\t-> User \"{user.Name}\", email: {user.Email}");
    }
} while (response.HasMoreResults);   
```