### PR TITLE
Minor improvements

### DIFF
--- a/src/ZendeskApi.Client/Models/CustomFields.cs
+++ b/src/ZendeskApi.Client/Models/CustomFields.cs
@@ -5,6 +5,19 @@ namespace ZendeskApi.Client.Models
 {
     public class CustomFields : List<CustomField>, IReadOnlyCustomFields, ICustomFields
     {
+        public CustomFields()
+        {
+            
+        }
+
+        public CustomFields(Dictionary<long, string> fields)
+        {
+            foreach (var field in fields)
+            {
+                this[field.Key] = field.Value;
+            }
+        }
+
         private void Set(long id, string value)
         {
             if (this.All(cf => cf.Id != id))

--- a/src/ZendeskApi.Client/Requests/TicketCreateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/TicketCreateRequest.cs
@@ -11,14 +11,21 @@ namespace ZendeskApi.Client.Requests
     /// </summary>
     public class TicketCreateRequest
     {
-        public TicketCreateRequest(string description)
+        public TicketCreateRequest()
         {
-            Description = description;
+            
         }
 
-        [JsonProperty("description")]
-        public string Description { get; set; }
+        public TicketCreateRequest(string initialComment, bool initialCommentIsPublic = false)
+        {
+            Comment = new TicketComment {Body = initialComment, IsPublic = initialCommentIsPublic};    
+        }
 
+        public TicketCreateRequest(TicketComment comment)
+        {
+            Comment = comment;
+        }
+        
         [JsonProperty("subject")]
         public string Subject { get; set; }
 

--- a/src/ZendeskApi.Client/Responses/TicketResponse.cs
+++ b/src/ZendeskApi.Client/Responses/TicketResponse.cs
@@ -13,13 +13,13 @@ namespace ZendeskApi.Client.Responses
         /// <summary>
         /// Automatically assigned when creating tickets
         /// </summary>
-        [JsonProperty]
+        [JsonProperty("id")]
         public long Id { get; internal set; }
 
         /// <summary>
         /// The API url of this ticket
         /// </summary>
-        [JsonProperty]
+        [JsonProperty("url")]
         public Uri Url { get; internal set; }
 
         /// <summary>

--- a/test/ZendeskApi.Client.Tests/Resources/TicketCommentsResourceTests.cs
+++ b/test/ZendeskApi.Client.Tests/Resources/TicketCommentsResourceTests.cs
@@ -26,23 +26,25 @@ namespace ZendeskApi.Client.Tests.Resources
             var ticket = await _ticketResource.CreateAsync(new TicketCreateRequest("description") { Subject = "Test 1" });
 
             var comments = await _resource.ListAsync(ticket.Id);
-            Assert.Empty(comments);
+            Assert.Equal(1, comments.Count());
+            Assert.NotNull(comments.ElementAt(0).Id);
+            Assert.Equal("description", comments.ElementAt(0).Body);
 
             await _resource.AddComment(ticket.Id, new Models.TicketComment { Body = "Hi there! im a comments..." });
 
             comments = await _resource.ListAsync(ticket.Id);
-            Assert.Equal(1, comments.Count());
-            Assert.NotNull(comments.ElementAt(0).Id);
-            Assert.Equal("Hi there! im a comments...", comments.ElementAt(0).Body);
+            Assert.Equal(2, comments.Count());
+            Assert.NotNull(comments.ElementAt(1).Id);
+            Assert.Equal("Hi there! im a comments...", comments.ElementAt(1).Body);
 
             await _resource.AddComment(ticket.Id, new Models.TicketComment { Body = "Hi there! im a second comment..." });
 
             comments = await _resource.ListAsync(ticket.Id);
-            Assert.Equal(2, comments.Count());
-            Assert.NotNull(comments.ElementAt(0).Id);
-            Assert.Equal("Hi there! im a comments...", comments.ElementAt(0).Body);
+            Assert.Equal(3, comments.Count());
             Assert.NotNull(comments.ElementAt(1).Id);
-            Assert.Equal("Hi there! im a second comment...", comments.ElementAt(1).Body);
+            Assert.Equal("Hi there! im a comments...", comments.ElementAt(1).Body);
+            Assert.NotNull(comments.ElementAt(2).Id);
+            Assert.Equal("Hi there! im a second comment...", comments.ElementAt(2).Body);
         }
     }
 }


### PR DESCRIPTION
1. `CustomFields` has dictionary type characteristics, so allow initialisation from one
2. Don't use the `description` key when creating a ticket, as ZD documentation suggests
3. Ticket `id` field was not deserialising as casing was wrong on `TicketRespons`.  Added `JsonProperty`