### PR TITLE
Fix ticket create and update responses

### DIFF
--- a/src/ZendeskApi.Client/Resources/ITicketsResource.cs
+++ b/src/ZendeskApi.Client/Resources/ITicketsResource.cs
@@ -25,12 +25,12 @@ namespace ZendeskApi.Client.Resources
         #endregion
 
         #region Create Tickets
-        Task<TicketResponse> CreateAsync(TicketCreateRequest ticket);
+        Task<TicketResponseContainer> CreateAsync(TicketCreateRequest ticket);
         Task<JobStatusResponse> CreateAsync(IEnumerable<TicketCreateRequest> tickets);
         #endregion
 
         #region Update Tickets
-        Task<TicketResponse> UpdateAsync(TicketUpdateRequest ticket);
+        Task<TicketResponseContainer> UpdateAsync(TicketUpdateRequest ticket);
         Task<JobStatusResponse> UpdateAsync(IEnumerable<TicketUpdateRequest> tickets);
         #endregion
 

--- a/src/ZendeskApi.Client/Resources/TicketsResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketsResource.cs
@@ -193,7 +193,7 @@ namespace ZendeskApi.Client.Resources
 
 
         #region Create Tickets
-        public async Task<TicketResponse> CreateAsync(TicketCreateRequest ticket)
+        public async Task<TicketResponseContainer> CreateAsync(TicketCreateRequest ticket)
         {
             using (_loggerScope(_logger, "CreateAsync"))
             using (var client = _apiClient.CreateClient())
@@ -209,7 +209,7 @@ namespace ZendeskApi.Client.Resources
                                     .Build(); 
                 }
 
-                return await response.Content.ReadAsAsync<TicketResponse>();
+                return await response.Content.ReadAsAsync<TicketResponseContainer>();
             }
         }
 
@@ -236,7 +236,7 @@ namespace ZendeskApi.Client.Resources
 
 
         #region Update Tickets
-        public async Task<TicketResponse> UpdateAsync(TicketUpdateRequest ticket)
+        public async Task<TicketResponseContainer> UpdateAsync(TicketUpdateRequest ticket)
         {
             using (_loggerScope(_logger, "UpdateAsync"))
             using (var client = _apiClient.CreateClient(ResourceUri))
@@ -257,7 +257,7 @@ namespace ZendeskApi.Client.Resources
                                     .Build();
                 }
 
-                return await response.Content.ReadAsAsync<TicketResponse>();
+                return await response.Content.ReadAsAsync<TicketResponseContainer>();
             }
         }
 

--- a/src/ZendeskApi.Client/Responses/TicketResponseContainer.cs
+++ b/src/ZendeskApi.Client/Responses/TicketResponseContainer.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace ZendeskApi.Client.Responses
+{
+    public class TicketResponseContainer
+    {
+        [JsonProperty("ticket")]
+        public TicketResponse Ticket { get; set; }
+    }
+}

--- a/test/ZendeskApi.Client.Tests/Resources/TicketCommentsResourceTests.cs
+++ b/test/ZendeskApi.Client.Tests/Resources/TicketCommentsResourceTests.cs
@@ -25,21 +25,21 @@ namespace ZendeskApi.Client.Tests.Resources
         {
             var ticket = await _ticketResource.CreateAsync(new TicketCreateRequest("description") { Subject = "Test 1" });
 
-            var comments = await _resource.ListAsync(ticket.Id);
+            var comments = await _resource.ListAsync(ticket.Ticket.Id);
             Assert.Equal(1, comments.Count());
             Assert.NotNull(comments.ElementAt(0).Id);
             Assert.Equal("description", comments.ElementAt(0).Body);
 
-            await _resource.AddComment(ticket.Id, new Models.TicketComment { Body = "Hi there! im a comments..." });
+            await _resource.AddComment(ticket.Ticket.Id, new Models.TicketComment { Body = "Hi there! im a comments..." });
 
-            comments = await _resource.ListAsync(ticket.Id);
+            comments = await _resource.ListAsync(ticket.Ticket.Id);
             Assert.Equal(2, comments.Count());
             Assert.NotNull(comments.ElementAt(1).Id);
             Assert.Equal("Hi there! im a comments...", comments.ElementAt(1).Body);
 
-            await _resource.AddComment(ticket.Id, new Models.TicketComment { Body = "Hi there! im a second comment..." });
+            await _resource.AddComment(ticket.Ticket.Id, new Models.TicketComment { Body = "Hi there! im a second comment..." });
 
-            comments = await _resource.ListAsync(ticket.Id);
+            comments = await _resource.ListAsync(ticket.Ticket.Id);
             Assert.Equal(3, comments.Count());
             Assert.NotNull(comments.ElementAt(1).Id);
             Assert.Equal("Hi there! im a comments...", comments.ElementAt(1).Body);

--- a/test/ZendeskApi.Client.Tests/Resources/TicketsResourceTests.cs
+++ b/test/ZendeskApi.Client.Tests/Resources/TicketsResourceTests.cs
@@ -261,8 +261,8 @@ namespace ZendeskApi.Client.Tests.Resources
                     }
                 });
 
-            Assert.NotEqual(0L, response.Id);
-            Assert.Equal("My printer is on fire!", response.Subject);
+            Assert.NotEqual(0L, response.Ticket.Id);
+            Assert.Equal("My printer is on fire!", response.Ticket.Subject);
         }
 
         [Fact]
@@ -294,7 +294,7 @@ namespace ZendeskApi.Client.Tests.Resources
                 Subject = "I COMMAND YOU TO UPDATE!!!"
             };
 
-            ticket = await _resource.UpdateAsync(updateTicketRequest);
+            ticket = (await _resource.UpdateAsync(updateTicketRequest)).Ticket;
 
             Assert.Equal("I COMMAND YOU TO UPDATE!!!", ticket.Subject);
         }
@@ -342,8 +342,8 @@ namespace ZendeskApi.Client.Tests.Resources
 
             foreach (var ticketCreateRequest in tickets)
             {
-                var ticket = await _resource.CreateAsync(ticketCreateRequest);
-                createdTickets.Add(ticket);
+                var response = await _resource.CreateAsync(ticketCreateRequest);
+                createdTickets.Add(response.Ticket);
             }
 
             return createdTickets.ToArray();

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/TicketResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/TicketResourceSampleSite.cs
@@ -157,16 +157,16 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                         }
 
                         var mapper = req.HttpContext.RequestServices.GetRequiredService<IMapper>();
-                        var ticketResponse = mapper.Map<TicketResponse>(ticket);
+                        var ticketResponse = mapper.Map<TicketResponseContainer>(ticket);
 
                         var state = req.HttpContext.RequestServices.GetRequiredService<State>();
-                        ticketResponse.Id = long.Parse(Rand.Next().ToString());
-                        ticketResponse.Url = new Uri($"https://company.zendesk.com/api/v2/tickets/{ticketResponse.Id}.json");
+                        ticketResponse.Ticket.Id = long.Parse(Rand.Next().ToString());
+                        ticketResponse.Ticket.Url = new Uri($"https://company.zendesk.com/api/v2/tickets/{ticketResponse.Ticket.Id}.json");
 
 
-                        HandleTicketComment(ticket.Comment, state, ticketResponse.Id);
+                        HandleTicketComment(ticket.Comment, state, ticketResponse.Ticket.Id);
 
-                        state.Tickets.Add(ticketResponse.Id, ticketResponse);
+                        state.Tickets.Add(ticketResponse.Ticket.Id, ticketResponse.Ticket);
 
                         resp.StatusCode = (int)HttpStatusCode.Created;
                         return resp.WriteAsJson(ticketResponse);
@@ -188,7 +188,7 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
 
                         HandleTicketComment(ticketRequest.Comment, state, ticketRequest.Id);
 
-                        var ticketResponse = state.Tickets[id];
+                        var ticketResponse = new TicketResponseContainer {Ticket = state.Tickets[id] };
                         var mapper = req.HttpContext.RequestServices.GetRequiredService<IMapper>();
                         mapper.Map(ticketRequest, ticketResponse);
 
@@ -242,6 +242,10 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     services.AddSingleton(_ => new State());
                     services.AddSingleton(_ => new MapperConfiguration(cfg =>
                         {
+                            cfg.CreateMap<TicketCreateRequest, TicketResponseContainer>()
+                                .ForMember(r => r.Ticket, r => r.MapFrom(req => req));
+                            cfg.CreateMap<TicketUpdateRequest, TicketResponseContainer>()
+                                .ForMember(r => r.Ticket, r => r.MapFrom(req => req));
                             cfg.CreateMap<TicketCreateRequest, TicketResponse>();
                             cfg.CreateMap<TicketUpdateRequest, TicketResponse>();
                         }).CreateMapper());


### PR DESCRIPTION
As documented at https://developer.zendesk.com/rest_api/docs/core/tickets#create-ticket, the response to a create or update ticket request is not the ticket directly, but instead an object with a ticket property.
