### PR TITLE
Fixed Delete Users response, added Deleted Users endpoint

### DIFF
--- a/src/ZendeskApi.Client/IZendeskClient.cs
+++ b/src/ZendeskApi.Client/IZendeskClient.cs
@@ -10,6 +10,7 @@ namespace ZendeskApi.Client
         ISearchResource Search { get; }
         IGroupsResource Groups { get; }
         IUsersResource Users { get; }
+        IDeletedUsersResource DeletedUsers { get; }
         IUserIdentityResource UserIdentities { get; }
         IAttachmentsResource Attachments { get; }
         ITicketFieldsResource TicketFields { get; }

--- a/src/ZendeskApi.Client/Resources/DeletedUsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/DeletedUsersResource.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ZendeskApi.Client.Exceptions;
+using ZendeskApi.Client.Extensions;
+using ZendeskApi.Client.Formatters;
+using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Resources
+{
+    /// <summary>
+    /// <see cref="https://developer.zendesk.com/rest_api/docs/core/users#list-deleted-users"/>
+    /// </summary>
+    public class DeletedUsersResource : IDeletedUsersResource
+    {
+        private const string ResourceUri = "api/v2/deleted_users";
+        private const string IncrementalResourceUri = "api/v2/incremental";
+
+        private readonly IZendeskApiClient _apiClient;
+        private readonly ILogger _logger;
+
+        private readonly Func<ILogger, string, IDisposable> _loggerScope = LoggerMessage.DefineScope<string>(typeof(DeletedUsersResource).Name + ": {0}");
+
+        public DeletedUsersResource(IZendeskApiClient apiClient, ILogger logger)
+        {
+            _apiClient = apiClient;
+            _logger = logger;
+        }
+
+        public async Task<UsersListResponse> ListAsync(PagerParameters pager = null)
+        {
+            using (_loggerScope(_logger, "ListAsync"))
+            using (var client = _apiClient.CreateClient())
+            {
+                var response = await client.GetAsync(ResourceUri, pager).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw await new ZendeskRequestExceptionBuilder()
+                        .WithResponse(response)
+                        .WithHelpDocsLink("core/users#list-deleted-users")
+                        .Build();
+                }
+
+                return await response.Content.ReadAsAsync<UsersListResponse>();
+            }
+        }
+
+        public async Task<UserResponse> GetAsync(long userId)
+        {
+            using (_loggerScope(_logger, $"GetAsync({userId})"))
+            using (var client = _apiClient.CreateClient(ResourceUri))
+            {
+                var response = await client.GetAsync(userId.ToString()).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.LogInformation("UserResponse {0} not found", userId);
+                    return null;
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw await new ZendeskRequestExceptionBuilder()
+                        .WithResponse(response)
+                        .WithHelpDocsLink("core/users#show-deleted-user")
+                        .Build();
+                }
+
+                var result = await response.Content.ReadAsAsync<SingleUserResponse>();
+                return result.UserResponse;
+            }
+        }
+
+        public async Task PermanentlyDeleteAsync(long userId)
+        {
+            using (_loggerScope(_logger, "DeleteAsync({userId})"))
+            using (var client = _apiClient.CreateClient(ResourceUri))
+            {
+                var response = await client.DeleteAsync(userId.ToString()).ConfigureAwait(false);
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    throw await new ZendeskRequestExceptionBuilder()
+                        .WithResponse(response)
+                        .WithExpectedHttpStatus(HttpStatusCode.OK)
+                        .WithHelpDocsLink("core/users#permanently-delete-user")
+                        .Build();
+                }
+            }
+        }
+    }
+}

--- a/src/ZendeskApi.Client/Resources/DeletedUsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/DeletedUsersResource.cs
@@ -17,7 +17,6 @@ namespace ZendeskApi.Client.Resources
     public class DeletedUsersResource : IDeletedUsersResource
     {
         private const string ResourceUri = "api/v2/deleted_users";
-        private const string IncrementalResourceUri = "api/v2/incremental";
 
         private readonly IZendeskApiClient _apiClient;
         private readonly ILogger _logger;

--- a/src/ZendeskApi.Client/Resources/IDeletedUsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/IDeletedUsersResource.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Resources
+{
+    public interface IDeletedUsersResource
+    {
+        #region List Deleted Users
+        Task<UsersListResponse> ListAsync(PagerParameters pager = null);
+        #endregion
+
+        #region Get Deleted Users
+        Task<UserResponse> GetAsync(long userId);
+        #endregion
+
+        #region Permanently Delete Users
+        Task PermanentlyDeleteAsync(long userId);
+        #endregion
+    }
+}

--- a/src/ZendeskApi.Client/Resources/UsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/UsersResource.cs
@@ -270,7 +270,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                         .WithResponse(response)
-                        .WithExpectedHttpStatus(HttpStatusCode.NoContent)
+                        .WithExpectedHttpStatus(HttpStatusCode.OK)
                         .WithHelpDocsLink("core/users#delete-user")
                         .Build();
                 }

--- a/src/ZendeskApi.Client/Resources/UsersResource.cs
+++ b/src/ZendeskApi.Client/Resources/UsersResource.cs
@@ -266,7 +266,7 @@ namespace ZendeskApi.Client.Resources
             {
                 var response = await client.DeleteAsync(userId.ToString()).ConfigureAwait(false);
 
-                if (response.StatusCode != HttpStatusCode.NoContent)
+                if (response.StatusCode != HttpStatusCode.OK)
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                         .WithResponse(response)

--- a/src/ZendeskApi.Client/ZendeskClient.cs
+++ b/src/ZendeskApi.Client/ZendeskClient.cs
@@ -34,6 +34,9 @@ namespace ZendeskApi.Client
         private Lazy<IUsersResource> UsersLazy => new Lazy<IUsersResource>(() => new UsersResource(_apiClient, _logger));
         public IUsersResource Users => UsersLazy.Value;
 
+        private Lazy<IDeletedUsersResource> DeletedUsersLazy => new Lazy<IDeletedUsersResource>(() => new DeletedUsersResource(_apiClient, _logger));
+        public IDeletedUsersResource DeletedUsers => DeletedUsersLazy.Value;
+
         private Lazy<IUserIdentityResource> UserIdentitiesLazy => new Lazy<IUserIdentityResource>(() => new UserIdentitiesResource(_apiClient, _logger));
         public IUserIdentityResource UserIdentities => UserIdentitiesLazy.Value;
 

--- a/test/ZendeskApi.Client.Tests/Resources/DeletedUsersResourceTests.cs
+++ b/test/ZendeskApi.Client.Tests/Resources/DeletedUsersResourceTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using Xunit;
+using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Resources;
+using ZendeskApi.Client.Responses;
+using ZendeskApi.Client.Tests.ResourcesSampleSites;
+
+namespace ZendeskApi.Client.Tests.Resources
+{
+    public class DeletedUsersResourceTests
+    {
+        private readonly DeletedUsersResource _resource;
+        private DeletedUsersResourceSampleSite _sample;
+
+        public DeletedUsersResourceTests()
+        {
+            IZendeskApiClient client = new DisposableZendeskApiClient(resource =>
+            {
+                _sample = new DeletedUsersResourceSampleSite(resource);
+                return _sample;
+            });
+            _resource = new DeletedUsersResource(client, NullLogger.Instance);
+        }
+
+        [Fact]
+        public async Task ShouldGetAllDeletedUsers()
+        {
+            var objs = (await _resource.ListAsync()).ToArray();
+
+            Assert.Equal(2, objs.Length);
+        }
+
+        [Fact]
+        public async Task ShouldGetAllUsersById()
+        {
+            var user1 = await _resource.GetAsync(1);
+
+            Assert.NotNull(user1);
+
+            var user2 = await _resource.GetAsync(2);
+
+            Assert.NotNull(user2);
+        }
+
+        [Fact]
+        public async Task ShouldPermanentlyDeleteUser()
+        {
+            var user = new UserResponse()
+            {
+                Id = 1,
+                Email = "Fu1@fu.com",
+                Name = "Kung Fu Wizard"
+            };
+
+            await _resource.PermanentlyDeleteAsync(user.Id);
+
+            var user2 = await _resource.GetAsync(user.Id);
+
+            Assert.Null(user2);
+        }
+    }
+}

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/DeletedUsersResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/DeletedUsersResourceSampleSite.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using ZendeskApi.Client.Extensions;
+using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Responses;
+using ZendeskApi.Client.Tests.Extensions;
+
+namespace ZendeskApi.Client.Tests.ResourcesSampleSites
+{
+    public class DeletedUsersResourceSampleSite : SampleSite
+    {
+        private class State
+        {
+            public readonly IDictionary<long, UserResponse> DeletedUsers = new Dictionary<long, UserResponse>()
+            {
+                {
+                    1,
+                    new UserResponse()
+                    {
+                        Id = 1,
+                        Name = "Kung Fu Wizard",
+                        Email = "Fu1@fu.com"
+                    }
+                },
+                { 
+                    2,
+                    new UserResponse()
+                    {
+                        Id = 2,
+                        Name = "some name",
+                        Email = "Fu2@fu.com"
+                    }
+                }
+            };
+        }
+
+        public static Action<IRouteBuilder> MatchesRequest
+        {
+            get
+            {
+                return rb => rb
+                    .MapGet("api/v2/deleted_users/{id}", (req, resp, routeData) =>
+                    {
+                        var id = long.Parse(routeData.Values["id"].ToString());
+
+                        var state = req.HttpContext.RequestServices.GetRequiredService<State>();
+
+                        if (!state.DeletedUsers.ContainsKey(id))
+                        {
+                            resp.StatusCode = (int)HttpStatusCode.NotFound;
+                            return Task.CompletedTask;
+                        }
+
+                        var user = state.DeletedUsers[id];
+
+                        resp.StatusCode = (int)HttpStatusCode.OK;
+                        return resp.WriteAsJson(new SingleUserResponse
+                        {
+                            UserResponse = user
+                        });
+                    })
+                    .MapGet("api/v2/deleted_users", (req, resp, routeData) =>
+                    {
+                        var state = req.HttpContext.RequestServices.GetRequiredService<State>();
+
+                        resp.StatusCode = (int)HttpStatusCode.OK;
+                        return resp.WriteAsJson(new UsersListResponse
+                        {
+                            Users = state.DeletedUsers.Values
+                        });
+                    })
+                    .MapDelete("api/v2/deleted_users/{id}", (req, resp, routeData) =>
+                    {
+                        var id = long.Parse(routeData.Values["id"].ToString());
+
+                        var state = req.HttpContext.RequestServices.GetRequiredService<State>();
+
+                        state.DeletedUsers.Remove(id);
+
+                        resp.StatusCode = (int)HttpStatusCode.OK;
+                        return Task.CompletedTask;
+                    });
+            }
+        }
+
+        private readonly TestServer _server;
+
+        private HttpClient _client;
+        public override HttpClient Client => _client;
+
+        public DeletedUsersResourceSampleSite(string resource)
+        {
+            var webhostbuilder = new WebHostBuilder();
+            webhostbuilder
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(_ => new State());
+                    services.AddSingleton(_ => new MapperConfiguration(cfg =>
+                    {
+                        cfg.CreateMap<UserUpdateRequest, UserResponse>();
+                        cfg.CreateMap<UserCreateRequest, UserResponse>();
+                    }).CreateMapper());
+                    services.AddRouting();
+                    services.AddMemoryCache();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouter(MatchesRequest);
+                });
+
+            _server = new TestServer(webhostbuilder);
+            _client = _server.CreateClient();
+
+            RefreshClient(resource);
+        }
+
+        public sealed override void RefreshClient(string resource)
+        {
+            _client = _server.CreateClient();
+            _client.BaseAddress = new Uri($"http://localhost/{CreateResource(resource)}");
+        }
+
+        private string CreateResource(string resource)
+        {
+            resource = resource?.Trim('/');
+
+            return resource != null ? resource + "/" : "";
+        }
+
+        public Uri BaseUri => Client.BaseAddress;
+
+        public override void Dispose()
+        {
+            Client.Dispose();
+            _server.Dispose();
+        }
+    }
+}

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/UsersResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/UsersResourceSampleSite.cs
@@ -212,7 +212,7 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
 
                         state.Users.Remove(id);
 
-                        resp.StatusCode = (int) HttpStatusCode.NoContent;
+                        resp.StatusCode = (int) HttpStatusCode.OK;
                         return Task.CompletedTask;
                     });
             }


### PR DESCRIPTION
The `DELETE /users/{id}` endpoint returns `OK`, but the client expects a `NoContent` response, so it currently fails.

Also, I added the `/deleted_users` endpoint which allow to permanently delete users. https://developer.zendesk.com/rest_api/docs/core/users#list-deleted-users