### PR TITLE
Default search sort order changed from Asc to Desc

### DIFF
--- a/src/ZendeskApi.Client/Queries/ZendeskQuery.cs
+++ b/src/ZendeskApi.Client/Queries/ZendeskQuery.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text;
 using ZendeskApi.Client.Models;
 
@@ -114,9 +114,9 @@ namespace ZendeskApi.Client.Queries
                 }
             }
 
-            if (_sortOrder == SortOrder.Asc)
+            if (_sortOrder == SortOrder.Desc)
             {
-                sb.Append("&sort_order=asc");
+                sb.Append("&sort_order=desc");
             }
 
             return sb.ToString();


### PR DESCRIPTION
The default sort order in the Zendesk API is Ascending. It must be possible to set the search order to Descending in the ZendeskApiClient, i.e. to explicitly change the default sort order.