### PR TITLE
CustomField allows value arrays

### DIFF
--- a/src/ZendeskApi.Client/Converters/CustomFieldConverter.cs
+++ b/src/ZendeskApi.Client/Converters/CustomFieldConverter.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Converters
+{
+    public class CustomFieldConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var customField = (CustomField)value;
+            var result = new JObject
+            {
+                {"id", customField.Id}
+            };
+
+            if (customField.Value != null)
+            {
+                result.Add("value", customField.Value);
+            }
+            else
+            {
+                result.Add("value", new JArray(customField.Values));
+            }
+
+            result.WriteTo(writer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            var customField = new CustomField()
+            {
+                Id = (long)token["id"]
+            };
+
+            var valueToken = token["value"];
+            if (valueToken.Type == JTokenType.Array)
+            {
+                customField.Values = valueToken.ToObject<List<string>>();
+            }
+            else
+            {
+                customField.Value = valueToken.ToObject<string>();
+            }
+
+            return customField;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(CustomField);
+        }
+    }
+}

--- a/src/ZendeskApi.Client/Models/CustomField.cs
+++ b/src/ZendeskApi.Client/Models/CustomField.cs
@@ -1,15 +1,19 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
+using ZendeskApi.Client.Converters;
 
 namespace ZendeskApi.Client.Models
 {
     [Description("custom_field")]
+    [JsonConverter(typeof(CustomFieldConverter))]
     public class CustomField
     {
         [JsonProperty("id")]
         public long Id { get; set; }
 
-        [JsonProperty("value")]
         public string Value { get; set; }
+
+        public List<string> Values { get; set; }
     }
 }

--- a/src/ZendeskApi.Client/Models/CustomFields.cs
+++ b/src/ZendeskApi.Client/Models/CustomFields.cs
@@ -18,6 +18,11 @@ namespace ZendeskApi.Client.Models
             }
         }
 
+        public CustomFields(List<CustomField> customFields)
+        {
+            AddRange(customFields);
+        }
+
         private void Set(long id, string value)
         {
             if (this.All(cf => cf.Id != id))
@@ -43,6 +48,27 @@ namespace ZendeskApi.Client.Models
         {
             get => Get(id);
             set => Set(id, value);
+        }
+
+        public List<string> GetValues(long id)
+        {
+            return this.FirstOrDefault(cf => cf.Id == id)?.Values;
+        }
+
+        public void SetValues(long id, List<string> values)
+        {
+            if (this.All(cf => cf.Id != id))
+            {
+                Add(new CustomField
+                {
+                    Id = id,
+                    Values = values
+                });
+            }
+            else
+            {
+                this.FirstOrDefault(cf => cf.Id == id).Values = values;
+            }
         }
     }
 }

--- a/src/ZendeskApi.Client/Models/ICustomFields.cs
+++ b/src/ZendeskApi.Client/Models/ICustomFields.cs
@@ -5,5 +5,9 @@ namespace ZendeskApi.Client.Models
     public interface ICustomFields : IList<CustomField>
     {
         string this[long id] { get; set; }
+
+        List<string> GetValues(long id);
+
+        void SetValues(long id, List<string> values);
     }
 }

--- a/src/ZendeskApi.Client/Models/IReadOnlyCustomFields.cs
+++ b/src/ZendeskApi.Client/Models/IReadOnlyCustomFields.cs
@@ -5,5 +5,9 @@ namespace ZendeskApi.Client.Models
     public interface IReadOnlyCustomFields : IReadOnlyList<CustomField>
     {
         string this[long id] { get; }
+
+        List<string> GetValues(long id);
+
+        void SetValues(long id, List<string> values);
     }
 }

--- a/test/ZendeskApi.Client.Tests/Converters/CustomFieldConverterTests.cs
+++ b/test/ZendeskApi.Client.Tests/Converters/CustomFieldConverterTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Xunit;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Tests.Converters
+{
+    public class CustomFieldConverterTests
+    {
+        [Fact]
+        public void CustomField_Deserializes_MultiValues_Correctly()
+        {
+            //Arrange
+            var ticketJson = File.ReadAllText(AppContext.BaseDirectory + "/Converters/testTicket.json");
+
+            //Act
+            var ticket = JsonConvert.DeserializeObject<Ticket>(ticketJson);
+
+            //Assert
+            AssertDeserializationWasSuccessful(ticket);
+        }
+
+        [Fact]
+        public void CustomField_Serializes_MultiValues_Correctly()
+        {
+            //Arrange
+            var ticket = new Ticket()
+            {
+                CustomFields = new CustomFields()
+                {
+                    new CustomField() {Id = 27612842, Value = "festive_delivery_request"},
+                    new CustomField() {Id = 360000027769, Values = new List<string>() { "fd_1st_january", "fd_2nd_january"}}
+                }
+            };
+
+            //Act
+            var ticketJson = JsonConvert.SerializeObject(ticket, Formatting.Indented);
+            var deserializedTicket = JsonConvert.DeserializeObject<Ticket>(ticketJson);
+
+            //Assert
+            AssertDeserializationWasSuccessful(deserializedTicket);
+        }
+
+        private void AssertDeserializationWasSuccessful(Ticket ticket)
+        {
+            var multiValueCustomField = ticket.CustomFields.Where(x => x.Values != null && x.Value == null);
+            var singleValueFields = ticket.CustomFields.Where(x => x.Value != null && x.Values == null);
+
+            Assert.Equal(2, ticket.CustomFields.Count);
+
+            Assert.Equal(1, multiValueCustomField.Count());
+            Assert.Equal(2, multiValueCustomField.First().Values.Count);
+            Assert.Contains(multiValueCustomField.First().Values, x => x == "fd_1st_january");
+            Assert.Contains(multiValueCustomField.First().Values, x => x == "fd_2nd_january");
+
+            Assert.Equal(1, singleValueFields.Count());
+        }
+    }
+}

--- a/test/ZendeskApi.Client.Tests/Converters/testTicket.json
+++ b/test/ZendeskApi.Client.Tests/Converters/testTicket.json
@@ -1,0 +1,70 @@
+{
+    "url": "",
+    "id": 18076817,
+    "external_id": null,
+    "via": {
+        "channel": "api",
+        "source": {
+            "rel": "inbound"
+        }
+    },
+    "created_at": "2011-12-31T12:42:32Z",
+    "updated_at": "2011-01-02T15:58:01Z",
+    "type": null,
+    "subject": "Festive Delivery Changes Request",
+    "raw_subject": "Festive Delivery Changes Request",
+    "description": "Auto-created by phone call from",
+    "priority": "normal",
+    "status": "solved",
+    "recipient": null,
+    "requester_id": 517281522,
+    "submitter_id": 517281522,
+    "assignee_id": 542358262,
+    "organization_id": 30688762,
+    "group_id": 24171311,
+    "collaborator_ids": [],
+    "follower_ids": [],
+    "email_cc_ids": [],
+    "forum_topic_id": null,
+    "problem_id": null,
+    "has_incidents": false,
+    "is_public": false,
+    "due_at": null,
+    "tags": [
+        "channel_phone",
+        "delivery_accepted",
+        "fd_1st_january",
+        "fd_2nd_january",
+        "festive_change_reverted",
+        "festive_delivery_request",
+        "satisfaction_offered",
+        "satisfaction_q217",
+        "segment_premium",
+        "ss_status_tracker_work_completed",
+        "task_delivery"
+    ],
+    "satisfaction_rating": {
+        "score": "bad",
+        "id": 360233956797,
+        "comment": "comment",
+        "reason": "The issue was not resolved",
+        "reason_id": 40089
+    },
+    "sharing_agreement_ids": [],
+    "custom_fields": [
+        {
+            "id": 27612842,
+            "value": "festive_delivery_request"
+        },
+        {
+            "id": 360000027769,
+            "value": ["fd_1st_january", "fd_2nd_january"]
+        }
+    ],
+    "followup_ids": [],
+    "ticket_form_id": 60502,
+    "brand_id": 44291,
+    "satisfaction_probability": null,
+    "allow_channelback": false,
+    "allow_attachments": true
+}

--- a/test/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
+++ b/test/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
@@ -28,4 +28,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Converters\testTicket.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- new property added to CustomField to account for custom fields where the value is an array instead of a primitive
- custom serializer/deserializer for CustomField and tests for the serializer/deserializer
- adjusted the contract (additive change) of CustomFields to account for the changes to CustomField