### PR TITLE
Adds handling of `null` values for custom fields to the CustomFieldConverter

### DIFF
--- a/src/ZendeskApi.Client/Converters/CustomFieldConverter.cs
+++ b/src/ZendeskApi.Client/Converters/CustomFieldConverter.cs
@@ -20,6 +20,10 @@ namespace ZendeskApi.Client.Converters
             {
                 result.Add("value", customField.Value);
             }
+            else if (customField.Values == null || customField.Values.Count == 0)
+            {
+                result.Add("value", null);
+            }
             else
             {
                 result.Add("value", new JArray(customField.Values));

--- a/test/ZendeskApi.Client.Tests/Converters/CustomFieldConverterTests.cs
+++ b/test/ZendeskApi.Client.Tests/Converters/CustomFieldConverterTests.cs
@@ -24,6 +24,19 @@ namespace ZendeskApi.Client.Tests.Converters
         }
 
         [Fact]
+        public void CustomField_Deserializes_NullValues_Correctly()
+        {
+            //Arrange
+            var ticketJson = File.ReadAllText(AppContext.BaseDirectory + "/Converters/testTicketNull.json");
+
+            //Act
+            var ticket = JsonConvert.DeserializeObject<Ticket>(ticketJson);
+
+            //Assert
+            AssertDeserializationWasSuccessful(ticket, true);
+        }
+
+        [Fact]
         public void CustomField_Serializes_MultiValues_Correctly()
         {
             //Arrange
@@ -44,10 +57,32 @@ namespace ZendeskApi.Client.Tests.Converters
             AssertDeserializationWasSuccessful(deserializedTicket);
         }
 
-        private void AssertDeserializationWasSuccessful(Ticket ticket)
+        [Fact]
+        public void CustomField_Serializes_Null_Correctly()
+        {
+            //Arrange
+            var ticket = new Ticket()
+            {
+                CustomFields = new CustomFields()
+                {
+                    new CustomField() {Id = 27612842, Value = null},
+                    new CustomField() {Id = 360000027769, Values = new List<string>() { "fd_1st_january", "fd_2nd_january"}}
+                }
+            };
+
+            //Act
+            var ticketJson = JsonConvert.SerializeObject(ticket, Formatting.Indented);
+            var deserializedTicket = JsonConvert.DeserializeObject<Ticket>(ticketJson);
+
+            //Assert
+            AssertDeserializationWasSuccessful(deserializedTicket, true);
+        }
+
+        private void AssertDeserializationWasSuccessful(Ticket ticket, bool expectNullValue = false)
         {
             var multiValueCustomField = ticket.CustomFields.Where(x => x.Values != null && x.Value == null);
             var singleValueFields = ticket.CustomFields.Where(x => x.Value != null && x.Values == null);
+            var nullValueFields = ticket.CustomFields.Where(x => x.Value == null && x.Values == null);
 
             Assert.Equal(2, ticket.CustomFields.Count);
 
@@ -56,7 +91,8 @@ namespace ZendeskApi.Client.Tests.Converters
             Assert.Contains(multiValueCustomField.First().Values, x => x == "fd_1st_january");
             Assert.Contains(multiValueCustomField.First().Values, x => x == "fd_2nd_january");
 
-            Assert.Equal(1, singleValueFields.Count());
+            Assert.Equal(expectNullValue ? 0 : 1, singleValueFields.Count());
+            Assert.Equal(expectNullValue ? 1 : 0, nullValueFields.Count());
         }
     }
 }

--- a/test/ZendeskApi.Client.Tests/Converters/testTicketNull.json
+++ b/test/ZendeskApi.Client.Tests/Converters/testTicketNull.json
@@ -1,0 +1,70 @@
+{
+    "url": "",
+    "id": 18076817,
+    "external_id": null,
+    "via": {
+        "channel": "api",
+        "source": {
+            "rel": "inbound"
+        }
+    },
+    "created_at": "2011-12-31T12:42:32Z",
+    "updated_at": "2011-01-02T15:58:01Z",
+    "type": null,
+    "subject": "Festive Delivery Changes Request",
+    "raw_subject": "Festive Delivery Changes Request",
+    "description": "Auto-created by phone call from",
+    "priority": "normal",
+    "status": "solved",
+    "recipient": null,
+    "requester_id": 517281522,
+    "submitter_id": 517281522,
+    "assignee_id": 542358262,
+    "organization_id": 30688762,
+    "group_id": 24171311,
+    "collaborator_ids": [],
+    "follower_ids": [],
+    "email_cc_ids": [],
+    "forum_topic_id": null,
+    "problem_id": null,
+    "has_incidents": false,
+    "is_public": false,
+    "due_at": null,
+    "tags": [
+        "channel_phone",
+        "delivery_accepted",
+        "fd_1st_january",
+        "fd_2nd_january",
+        "festive_change_reverted",
+        "festive_delivery_request",
+        "satisfaction_offered",
+        "satisfaction_q217",
+        "segment_premium",
+        "ss_status_tracker_work_completed",
+        "task_delivery"
+    ],
+    "satisfaction_rating": {
+        "score": "bad",
+        "id": 360233956797,
+        "comment": "comment",
+        "reason": "The issue was not resolved",
+        "reason_id": 40089
+    },
+    "sharing_agreement_ids": [],
+    "custom_fields": [
+        {
+            "id": 27612842,
+            "value": null
+        },
+        {
+            "id": 360000027769,
+            "value": ["fd_1st_january", "fd_2nd_january"]
+        }
+    ],
+    "followup_ids": [],
+    "ticket_form_id": 60502,
+    "brand_id": 44291,
+    "satisfaction_probability": null,
+    "allow_channelback": false,
+    "allow_attachments": true
+}

--- a/test/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
+++ b/test/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
@@ -29,8 +29,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Converters\testTicketNull.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Converters\testTicket.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes backwards compatibility issue where `null`-valued custom fields were rendered as `{ 1234: [ null ] }` i.e. array valued. 