### PR TITLE
Created JobStatus Resource

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-version: 3.2.0-alpha-{build}
+version: 3.3.0-alpha-{build}
 configuration: Release
 before_build:
   - dotnet restore

--- a/src/ZendeskApi.Client/Converters/JobStatusResultConverter.cs
+++ b/src/ZendeskApi.Client/Converters/JobStatusResultConverter.cs
@@ -10,7 +10,7 @@ namespace ZendeskApi.Client.Converters
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -33,7 +33,9 @@ namespace ZendeskApi.Client.Converters
 
         public override bool CanConvert(Type objectType)
         {
-            throw new NotImplementedException();
+            return objectType == typeof(IEnumerable<JobStatusResult>) ||
+                   objectType == typeof(JArray) ||
+                   objectType == typeof(JObject);
         }
     }
 }

--- a/src/ZendeskApi.Client/Converters/JobStatusResultConverter.cs
+++ b/src/ZendeskApi.Client/Converters/JobStatusResultConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Converters
+{
+    public class JobStatusResultConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartObject:
+                    JObject item = JObject.Load(reader);
+                    var itemAsResult = item.ToObject<JobStatusResult>();
+                    return new [] {itemAsResult};
+                case JsonToken.StartArray:
+                {
+                    JArray array = JArray.Load(reader);
+                    return array.ToObject<IEnumerable<JobStatusResult>>();
+                }
+            }
+
+            return null; //We shouldn't ever be getting something other than an Object/Array.
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ZendeskApi.Client/IZendeskClient.cs
+++ b/src/ZendeskApi.Client/IZendeskClient.cs
@@ -20,5 +20,6 @@ namespace ZendeskApi.Client
         IRequestsResource Requests { get; }
         ISatisfactionRatingsResource SatisfactionRatings { get; }
         IUserFieldsResource UserFields { get; }
+        IJobStatusResource JobStatuses { get; }
     }
 }

--- a/src/ZendeskApi.Client/Models/JobStatus.cs
+++ b/src/ZendeskApi.Client/Models/JobStatus.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
+using ZendeskApi.Client.Converters;
 
 namespace ZendeskApi.Client.Models
 {
@@ -48,6 +49,7 @@ namespace ZendeskApi.Client.Models
         /// Result data from processed tasks
         /// </summary>
         [JsonProperty("results")]
+        [JsonConverter(typeof(JobStatusResultConverter))]
         public IEnumerable<JobStatusResult> Results { get; set; }
     }
 

--- a/src/ZendeskApi.Client/Resources/IJobStatusResource.cs
+++ b/src/ZendeskApi.Client/Resources/IJobStatusResource.cs
@@ -17,7 +17,19 @@ namespace ZendeskApi.Client.Resources
 
         #region Show
 
+        /// <summary>
+        /// Shows the status of a background job.
+        /// A job may no longer exist to query. Zendesk only logs the last 100 jobs. Jobs also expire within an hour.
+        /// </summary>
+        /// <param name="statusId">ID of the requested job status.</param>
+        /// <returns></returns>
         Task<JobStatusResponse> GetAsync(string statusId);
+        
+        /// <summary>
+        /// Shows the status of multiple background jobs.
+        /// A job may no longer exist to query. Zendesk only logs the last 100 jobs. Jobs also expire within an hour.
+        /// </summary>
+        /// <param name="statusIds">Array of IDs of requested job statuses.</param>
         Task<IPagination<JobStatusResponse>> GetAsync(string[] statusIds, PagerParameters pagerParameters = null);        
 
         #endregion

--- a/src/ZendeskApi.Client/Resources/IJobStatusResource.cs
+++ b/src/ZendeskApi.Client/Resources/IJobStatusResource.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Resources
+{
+    public interface IJobStatusResource
+    {
+        #region List
+        
+        /// <summary>
+        /// Shows the current statuses for background jobs running.
+        /// </summary>
+        Task<IPagination<JobStatusResponse>> ListAsync(PagerParameters pagerParameters = null);
+        
+        #endregion
+
+        #region Show
+
+        Task<JobStatusResponse> GetAsync(string statusId);
+        Task<IPagination<JobStatusResponse>> GetAsync(string[] statusIds, PagerParameters pagerParameters = null);        
+
+        #endregion
+    }
+}

--- a/src/ZendeskApi.Client/Resources/JobStatusResource.cs
+++ b/src/ZendeskApi.Client/Resources/JobStatusResource.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ZendeskApi.Client.Exceptions;
+using ZendeskApi.Client.Extensions;
+using ZendeskApi.Client.Formatters;
+using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Resources
+{
+    public class JobStatusResource : IJobStatusResource
+    {
+        private const string ResourceUri = "api/v2/job_statuses";
+        
+        private readonly IZendeskApiClient _apiClient;
+        private readonly ILogger _logger;
+
+        private readonly Func<ILogger, string, IDisposable> _loggerScope = LoggerMessage.DefineScope<string>(typeof(JobStatusResource).Name + ": {0}");
+
+        public JobStatusResource(IZendeskApiClient apiClient, ILogger logger)
+        {
+            _apiClient = apiClient;
+            _logger = logger;
+        }
+
+        #region List
+
+        public async Task<IPagination<JobStatusResponse>> ListAsync(PagerParameters pagerParameters = null)
+        {
+            using (_loggerScope(_logger, "ListAsync"))
+            using (var client = _apiClient.CreateClient())
+            {
+                var response = await client.GetAsync(ResourceUri, pagerParameters).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                    throw await new ZendeskRequestExceptionBuilder()
+                        .WithResponse(response)
+                        .WithHelpDocsLink("support/job_statuses#list-job-statuses")
+                        .Build();
+
+                return await response.Content.ReadAsAsync<JobStatusListResponse>();
+            }
+        }
+
+        #endregion
+
+        #region Show
+
+        public async Task<JobStatusResponse> GetAsync(string statusId)
+        {
+            using (_loggerScope(_logger, $"GetAsync({statusId})"))
+            using (var client = _apiClient.CreateClient(ResourceUri))
+            {
+                var response = await client.GetAsync(statusId).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.LogInformation($"JobStatus not found: {statusId}");
+                    return null;
+                }
+                
+                if (!response.IsSuccessStatusCode)
+                    throw await new ZendeskRequestExceptionBuilder()
+                        .WithResponse(response)
+                        .WithHelpDocsLink("support/job_statuses#show-job-status")
+                        .Build();
+
+                var result = await response.Content.ReadAsAsync<SingleJobStatusResponse>();
+                return result.JobStatus;
+            }
+        }
+
+        public async Task<IPagination<JobStatusResponse>> GetAsync(string[] statusIds, PagerParameters pagerParameters = null)
+        {
+            using (_loggerScope(_logger, $"GetAsync({ZendeskFormatter.ToCsv(statusIds)})"))
+            using (var client = _apiClient.CreateClient(ResourceUri))
+            {
+                var response = await client.GetAsync($"show_many?ids={ZendeskFormatter.ToCsv(statusIds)}", pagerParameters)
+                    .ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                    throw await new ZendeskRequestExceptionBuilder()
+                        .WithResponse(response)
+                        .WithHelpDocsLink("support/job_statuses#show-many-job-statuses")
+                        .Build();
+
+                return await response.Content.ReadAsAsync<JobStatusListResponse>();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/ZendeskApi.Client/Responses/JobStatusListResponse.cs
+++ b/src/ZendeskApi.Client/Responses/JobStatusListResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Responses
+{
+    [JsonObject]
+    public class JobStatusListResponse : PaginationResponse<JobStatusResponse>
+    {
+        [JsonProperty("job_statuses")]
+        public IEnumerable<JobStatusResponse> JobStatuses { get; set; }
+
+        protected override IEnumerable<JobStatusResponse> Enumerable => JobStatuses;
+    }
+}

--- a/src/ZendeskApi.Client/Responses/SingleJobStatusResponse.cs
+++ b/src/ZendeskApi.Client/Responses/SingleJobStatusResponse.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Responses
+{
+    public class SingleJobStatusResponse
+    {
+        [JsonProperty("job_status")]
+        public JobStatusResponse JobStatus { get; set; }
+    }
+}

--- a/src/ZendeskApi.Client/ZendeskClient.cs
+++ b/src/ZendeskApi.Client/ZendeskClient.cs
@@ -63,5 +63,10 @@ namespace ZendeskApi.Client
 
         private Lazy<IUserFieldsResource> UserFieldsLazy => new Lazy<IUserFieldsResource>(() => new UserFieldsResource(_apiClient, _logger));
         public IUserFieldsResource UserFields => UserFieldsLazy.Value;
+
+        private Lazy<IJobStatusResource> JobStatusesLazy =>
+            new Lazy<IJobStatusResource>(() => new JobStatusResource(_apiClient, _logger));
+
+        public IJobStatusResource JobStatuses => JobStatusesLazy.Value;
     }
 }

--- a/test/ZendeskApi.Client.Tests/Converters/JobStatusResultConverterTests.cs
+++ b/test/ZendeskApi.Client.Tests/Converters/JobStatusResultConverterTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Newtonsoft.Json;
+using Xunit;
+using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Responses;
+
+namespace ZendeskApi.Client.Tests.Converters
+{
+    public class JobStatusResultConverterTests
+    {
+        [Fact]
+        public void JobStatus_Result_AsObject_Deserializes_Into_Enumerable()
+        {
+            var json ="{\"job_status\":{\"id\":\"07d0f71323c2aba7707df154ef05b342\",\"url\":\"https://justeatukpoc1399564481.zendesk.com/api/v2/job_statuses/07d0f71323c2aba7707df154ef05b342.json\",\"total\":12,\"progress\":12,\"status\":\"completed\",\"message\":\"Completed at 2019-03-18 15:31:35 +0000\",\"results\":{\"success\":true}}}";
+
+            var deserialized = JsonConvert.DeserializeObject<SingleJobStatusResponse>(json);
+            Assert.Single(deserialized.JobStatus.Results);
+            Assert.True(deserialized.JobStatus.Results.First().Success);
+        }
+
+        [Fact]
+        public void JobStatus_Result_AsArray_WithOneItem_Deserializes_Into_Enumerable()
+        {
+            var json = "{\"job_status\":{\"id\":\"07d0f71323c2aba7707df154ef05b342\",\"url\":\"https://justeatukpoc1399564481.zendesk.com/api/v2/job_statuses/07d0f71323c2aba7707df154ef05b342.json\",\"total\":12,\"progress\":12,\"status\":\"completed\",\"message\":\"Completed at 2019-03-18 15:31:35 +0000\",\"results\":[{\"account_id\":523942,\"id\":354183,\"title\":\"Chatbot Chat\",\"status\":\"Deleted\",\"action\":\"delete\",\"success\":true,\"errors\":\"\"}]}}";
+            
+            var deserialized = JsonConvert.DeserializeObject<SingleJobStatusResponse>(json);
+            Assert.Single(deserialized.JobStatus.Results);
+        }
+
+        [Fact]
+        public void JobStatus_Result_AsArray_WithMultipleItems_Deserializes_Into_Enumerable()
+        {
+            var json = "{\"job_status\":{\"id\":\"07d0f71323c2aba7707df154ef05b342\",\"url\":\"https://justeatukpoc1399564481.zendesk.com/api/v2/job_statuses/07d0f71323c2aba7707df154ef05b342.json\",\"total\":12,\"progress\":12,\"status\":\"completed\",\"message\":\"Completed at 2019-03-18 15:31:35 +0000\",\"results\":[{\"account_id\":523942,\"id\":354183,\"title\":\"Chatbot Chat\",\"status\":\"Deleted\",\"action\":\"delete\",\"success\":true,\"errors\":\"\"},{\"account_id\":523942,\"id\":354182,\"title\":\"Chatbot Chat\",\"status\":\"Deleted\",\"action\":\"delete\",\"success\":true,\"errors\":\"\"}]}}";
+            
+            var deserialized = JsonConvert.DeserializeObject<SingleJobStatusResponse>(json);
+            Assert.Equal(2, deserialized.JobStatus.Results.Count());
+        }
+        
+    }
+}

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/JobStatusResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/JobStatusResourceSampleSite.cs
@@ -1,7 +1,0 @@
-namespace ZendeskApi.Client.Tests.ResourcesSampleSites
-{
-    public class JobStatusResourceSampleSite
-    {
-        
-    }
-}

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/JobStatusResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/JobStatusResourceSampleSite.cs
@@ -1,0 +1,7 @@
+namespace ZendeskApi.Client.Tests.ResourcesSampleSites
+{
+    public class JobStatusResourceSampleSite
+    {
+        
+    }
+}


### PR DESCRIPTION
# Changes
* New `JobStatus` Resource has been created
* `JobStatusResultConverter` had to be created to workaround an issue in the Zendesk 
     * Occasionally the **results** key within a job_status would be an Object, instead of an Array (as specified in the API Documentation)