### PR TITLE
Upped Version Minor in csproj

### DIFF
--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Description>A Zendesk Api Client for use with the ZendeskApi v2</Description>
+    <PackageVersion>3.3.0-alpha-0</PackageVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Seems as if this version number is also used within Appveyor when creating the NuGet package. Caused an issue in the previous commit in which the minor wasn't correctly updated.