### PR TITLE
Fixed expected response code when bulk creating tickets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-version: 3.3.0-alpha-{build}
+version: 3.3.1-alpha-{build}
 configuration: Release
 before_build:
   - dotnet restore

--- a/src/ZendeskApi.Client/Resources/TicketsResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketsResource.cs
@@ -49,7 +49,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                 .WithResponse(response)
-                                .WithHelpDocsLink("core/tickets#list-tickets")
+                                .WithHelpDocsLink("support/tickets#list-tickets")
                                 .Build();
                 }
 
@@ -74,7 +74,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
-                                    .WithHelpDocsLink("core/tickets#list-tickets")
+                                    .WithHelpDocsLink("support/tickets#list-tickets")
                                     .Build();
                 }
 
@@ -99,7 +99,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
-                                    .WithHelpDocsLink("core/tickets#list-tickets")
+                                    .WithHelpDocsLink("support/tickets#list-tickets")
                                     .Build();
                 }
 
@@ -124,7 +124,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
-                                    .WithHelpDocsLink("core/tickets#list-tickets")
+                                    .WithHelpDocsLink("support/tickets#list-tickets")
                                     .Build();
                 }
 
@@ -149,7 +149,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
-                                    .WithHelpDocsLink("core/tickets#list-tickets")
+                                    .WithHelpDocsLink("support/tickets#list-tickets")
                                     .Build();
                 }
 
@@ -207,7 +207,7 @@ namespace ZendeskApi.Client.Resources
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
                                     .WithExpectedHttpStatus(HttpStatusCode.Created)
-                                    .WithHelpDocsLink("core/tickets#create-ticket")
+                                    .WithHelpDocsLink("support/tickets#create-ticket")
                                     .Build(); 
                 }
 
@@ -222,16 +222,16 @@ namespace ZendeskApi.Client.Resources
             {
                 var response = await client.PostAsJsonAsync("create_many", new TicketListRequest<TicketCreateRequest>(tickets)).ConfigureAwait(false);
 
-                if (response.StatusCode != HttpStatusCode.Created)
+                if (response.StatusCode != HttpStatusCode.OK)
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
                                     .WithExpectedHttpStatus(HttpStatusCode.Created)
-                                    .WithHelpDocsLink("core/tickets#create-many-tickets")
+                                    .WithHelpDocsLink("support/tickets#create-many-tickets")
                                     .Build();
                 }
 
-                return await response.Content.ReadAsAsync<JobStatusResponse>();
+                return (await response.Content.ReadAsAsync<SingleJobStatusResponse>()).JobStatus;
             }
         }
         #endregion
@@ -255,7 +255,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
-                                    .WithHelpDocsLink("core/tickets#update-ticket")
+                                    .WithHelpDocsLink("support/tickets#update-ticket")
                                     .Build();
                 }
 
@@ -274,7 +274,7 @@ namespace ZendeskApi.Client.Resources
                 {
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
-                                    .WithHelpDocsLink("core/tickets#update-many-tickets")
+                                    .WithHelpDocsLink("support/tickets#update-many-tickets")
                                     .Build();
                 }
 
@@ -332,7 +332,7 @@ namespace ZendeskApi.Client.Resources
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
                                     .WithExpectedHttpStatus(HttpStatusCode.NoContent)
-                                    .WithHelpDocsLink("core/tickets#delete-ticket")
+                                    .WithHelpDocsLink("support/tickets#delete-ticket")
                                     .Build();
                 }
             }
@@ -364,7 +364,7 @@ namespace ZendeskApi.Client.Resources
                     throw await new ZendeskRequestExceptionBuilder()
                                     .WithResponse(response)
                                     .WithExpectedHttpStatus(HttpStatusCode.OK)
-                                    .WithHelpDocsLink("core/tickets#bulk-delete-tickets")
+                                    .WithHelpDocsLink("support/tickets#bulk-delete-tickets")
                                     .Build();
                 }
             }

--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Description>A Zendesk Api Client for use with the ZendeskApi v2</Description>
-    <PackageVersion>3.3.0-alpha-0</PackageVersion>
+    <PackageVersion>3.3.1-alpha-0</PackageVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
# Changes
* Fixed expected response code within `TicketResource`'s `CreateAsync` for bulk ticket creation.
    * API Returns a 200 OK for bulk creations.
* Fixed HelpDoc Link throughout tickets resource.
* Fixed return object of `TicketResource`'s `CreateAsync` for bulk ticket creation.
    * Was parsing the response incorrectly, and creating an empty `JobStatus` object.
* Increased patch version number.