### PR TITLE
Resolve #169 - Changed ExternalId field type to string

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-version: 3.3.1-alpha-{build}
+version: 3.3.2-alpha-{build}
 configuration: Release
 before_build:
   - dotnet restore

--- a/src/ZendeskApi.Client/Requests/TicketUpdateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/TicketUpdateRequest.cs
@@ -102,7 +102,7 @@ namespace ZendeskApi.Client.Requests
         /// An ID to link tickets to local records
         /// </summary>
         [JsonProperty("external_id")]
-        public long? ExternalId { get; set; }
+        public string ExternalId { get; set; }
 
         /// <summary>
         /// For tickets of type "incident", the numeric ID of the problem the incident is linked to, if any

--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Description>A Zendesk Api Client for use with the ZendeskApi v2</Description>
-    <PackageVersion>3.3.1-alpha-0</PackageVersion>
+    <PackageVersion>3.3.2-alpha-0</PackageVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
# Changes
* Changed `TicketUpdateRequest.ExternalId` type to String - as per Zendesk documentation (Resolves #169)
* Increased version patch number (As we're still in alpha).