### PR TITLE
Fixes Request Problems within TicketFields Resource

### DIFF
--- a/src/ZendeskApi.Client/Requests/TicketFieldCreateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/TicketFieldCreateRequest.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using ZendeskApi.Client.Models;
+
+namespace ZendeskApi.Client.Requests
+{
+    /// <summary>
+    /// See: https://developer.zendesk.com/rest_api/docs/support/ticket_fields#create-ticket-field
+    /// </summary>
+    public class TicketFieldCreateRequest
+    {
+        public TicketFieldCreateRequest(TicketField ticketField)
+        {
+            TicketField = ticketField;
+        }
+        
+        [JsonProperty("ticket_field")]
+        public TicketField TicketField { get; set; }
+    }
+}

--- a/src/ZendeskApi.Client/Requests/TicketFieldCreateUpdateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/TicketFieldCreateUpdateRequest.cs
@@ -7,9 +7,9 @@ namespace ZendeskApi.Client.Requests
     /// <summary>
     /// See: https://developer.zendesk.com/rest_api/docs/support/ticket_fields#create-ticket-field
     /// </summary>
-    public class TicketFieldCreateRequest
+    public class TicketFieldCreateUpdateRequest
     {
-        public TicketFieldCreateRequest(TicketField ticketField)
+        public TicketFieldCreateUpdateRequest(TicketField ticketField)
         {
             TicketField = ticketField;
         }

--- a/src/ZendeskApi.Client/Resources/TicketFieldsResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFieldsResource.cs
@@ -61,10 +61,10 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<TicketField> CreateAsync(TicketField ticketField)
         {
-            using (_loggerScope(_logger, $"PostAsync"))
+            using (_loggerScope(_logger, "PostAsync"))
             using (var client = _apiClient.CreateClient())
             {
-                var request = new TicketFieldCreateRequest(ticketField);
+                var request = new TicketFieldCreateUpdateRequest(ticketField);
                 var response = await client.PostAsJsonAsync(ResourceUri, request).ConfigureAwait(false);
 
                 if (response.StatusCode != System.Net.HttpStatusCode.Created)
@@ -82,10 +82,11 @@ namespace ZendeskApi.Client.Resources
 
         public async Task<TicketField> UpdateAsync(TicketField ticketField)
         {
-            using (_loggerScope(_logger, $"PutAsync"))
+            using (_loggerScope(_logger, "PutAsync"))
             using (var client = _apiClient.CreateClient(ResourceUri))
             {
-                var response = await client.PutAsJsonAsync(ticketField.Id.ToString(), ticketField).ConfigureAwait(false);
+                var request = new TicketFieldCreateUpdateRequest(ticketField);
+                var response = await client.PutAsJsonAsync(ticketField.Id.ToString(), request).ConfigureAwait(false);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
@@ -95,7 +96,8 @@ namespace ZendeskApi.Client.Resources
 
                 response.EnsureSuccessStatusCode();
 
-                return await response.Content.ReadAsAsync<TicketField>();
+                var result = await response.Content.ReadAsAsync<TicketFieldResponse>();
+                return result.TicketField;
             }
         }
 

--- a/src/ZendeskApi.Client/Resources/TicketFieldsResource.cs
+++ b/src/ZendeskApi.Client/Resources/TicketFieldsResource.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ZendeskApi.Client.Extensions;
 using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Requests;
 using ZendeskApi.Client.Responses;
 
 namespace ZendeskApi.Client.Resources
@@ -63,7 +64,8 @@ namespace ZendeskApi.Client.Resources
             using (_loggerScope(_logger, $"PostAsync"))
             using (var client = _apiClient.CreateClient())
             {
-                var response = await client.PostAsJsonAsync(ResourceUri, ticketField).ConfigureAwait(false);
+                var request = new TicketFieldCreateRequest(ticketField);
+                var response = await client.PostAsJsonAsync(ResourceUri, request).ConfigureAwait(false);
 
                 if (response.StatusCode != System.Net.HttpStatusCode.Created)
                 {
@@ -73,7 +75,8 @@ namespace ZendeskApi.Client.Resources
                         "See: https://developer.zendesk.com/rest_api/docs/core/ticket_fields#create-ticket-field");
                 }
 
-                return await response.Content.ReadAsAsync<TicketField>();
+                var result = await response.Content.ReadAsAsync<TicketFieldResponse>();
+                return result.TicketField;
             }
         }
 

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/TicketFieldsResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/TicketFieldsResourceSampleSite.cs
@@ -55,7 +55,7 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     })
                     .MapPost("api/v2/ticket_fields", (req, resp, routeData) =>
                     {
-                        var ticket = req.Body.ReadAs<TicketFieldCreateRequest>();
+                        var ticket = req.Body.ReadAs<TicketFieldCreateUpdateRequest>();
                         Assert.NotNull(ticket);
                         var ticketField = ticket.TicketField;
 
@@ -78,14 +78,15 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     {
                         var id = long.Parse(routeData.Values["id"].ToString());
 
-                        var ticket = req.Body.ReadAs<TicketField>();
+                        var ticket = req.Body.ReadAs<TicketFieldCreateUpdateRequest>();
+                        Assert.NotNull(ticket);
 
                         var state = req.HttpContext.RequestServices.GetRequiredService<State>();
 
-                        state.TicketFields[id] = ticket;
+                        state.TicketFields[id] = ticket.TicketField;
 
                         resp.StatusCode = (int)HttpStatusCode.OK;
-                        return resp.WriteAsJson(state.TicketFields[id]);
+                        return resp.WriteAsJson(new TicketFieldResponse{TicketField = state.TicketFields[id]});
                     })
                     .MapDelete("api/v2/ticket_fields/{id}", (req, resp, routeData) =>
                     {

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/TicketFieldsResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/TicketFieldsResourceSampleSite.cs
@@ -9,8 +9,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 using ZendeskApi.Client.Extensions;
 using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Requests;
 using ZendeskApi.Client.Responses;
 using ZendeskApi.Client.Tests.Extensions;
 
@@ -53,9 +55,11 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     })
                     .MapPost("api/v2/ticket_fields", (req, resp, routeData) =>
                     {
-                        var ticket = req.Body.ReadAs<TicketField>();
+                        var ticket = req.Body.ReadAs<TicketFieldCreateRequest>();
+                        Assert.NotNull(ticket);
+                        var ticketField = ticket.TicketField;
 
-                        if (ticket.Tag != null && ticket.Tag.Contains("error"))
+                        if (ticketField.Tag != null && ticketField.Tag.Contains("error"))
                         {
                             resp.StatusCode = (int)HttpStatusCode.PaymentRequired; // It doesnt matter as long as not 201
 
@@ -64,8 +68,8 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
 
                         var state = req.HttpContext.RequestServices.GetRequiredService<State>();
 
-                        ticket.Id = long.Parse(Rand.Next().ToString());
-                        state.TicketFields.Add(ticket.Id.Value, ticket);
+                        ticketField.Id = long.Parse(Rand.Next().ToString());
+                        state.TicketFields.Add(ticketField.Id.Value, ticketField);
 
                         resp.StatusCode = (int)HttpStatusCode.Created;
                         return resp.WriteAsJson(ticket);


### PR DESCRIPTION
# Changes
* Fixes the [`TicketFieldsResource.CreateAsync`](https://github.com/justeat/ZendeskApiClient/pull/171/files#diff-5a752b961565f3560c3f259a37541ef4R62) method (resolves #144)
* Fixes the [`TicketFieldsResource.UpdateAsync`](https://github.com/justeat/ZendeskApiClient/pull/171/files#diff-5a752b961565f3560c3f259a37541ef4R83) method.
* Implemented a new [`TicketFieldCreateUpdateRequest`](https://github.com/justeat/ZendeskApiClient/pull/171/files#diff-8c817f3c015789957b7d42f7c4ef37abR10) which is used when sending off TicketFields Create/Update requests.