### PR TITLE
[DNMY] refactor to use separate model for organization membership creates

### DIFF
--- a/src/ZendeskApi.Client/Models/IZendeskEntity.cs
+++ b/src/ZendeskApi.Client/Models/IZendeskEntity.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ZendeskApi.Client.Models
+{
+    public interface IZendeskEntity
+    {
+        long Id { get; set; }
+        DateTime? CreatedAt { get; set; }
+        DateTime? UpdatedAt { get; set; }
+    }
+}

--- a/src/ZendeskApi.Client/Models/OrganizationMembership.cs
+++ b/src/ZendeskApi.Client/Models/OrganizationMembership.cs
@@ -1,22 +1,22 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 
 namespace ZendeskApi.Client.Models
 {
     [JsonObject("organization_membership")]
-    public class OrganizationMembership
+    public class OrganizationMembership : IZendeskEntity
     {
         [JsonProperty]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         [JsonProperty("user_id")]
-        public long? UserId { get; set; }
+        public long UserId { get; set; }
 
         [JsonProperty("organization_id")]
-        public long? OrganizationId { get; set; }
+        public long OrganizationId { get; set; }
 
         [JsonProperty("default")]
-        public bool? Default { get; set; }
+        public bool Default { get; set; }
 
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }

--- a/src/ZendeskApi.Client/Requests/Organization/OrganizationMembershipCreateRequest.cs
+++ b/src/ZendeskApi.Client/Requests/Organization/OrganizationMembershipCreateRequest.cs
@@ -5,15 +5,19 @@ namespace ZendeskApi.Client.Requests
 {
     public class OrganizationMembershipCreateRequest
     {
-        public OrganizationMembershipCreateRequest(OrganizationMembership membership)
-        {
-            OrganizationMembership = membership;
-        }
+        [JsonProperty("user_id")]
+        public long UserId { get; set; }
 
-        /// <summary>
-        /// The OrganizationMembership to create
-        /// </summary>
-        [JsonProperty("organization_membership")]
-        public OrganizationMembership OrganizationMembership { get; set; }
+        [JsonProperty("organization_id")]
+        public long OrganizationId { get; set; }
+
+        public OrganizationMembershipCreateRequest()
+        { }
+
+        public OrganizationMembershipCreateRequest(OrganizationMembership organizationMembership)
+        {
+            UserId = organizationMembership.UserId;
+            OrganizationId = organizationMembership.OrganizationId;
+        }
     }
 }

--- a/src/ZendeskApi.Client/Requests/Organization/OrganizationMembershipListRequest.cs
+++ b/src/ZendeskApi.Client/Requests/Organization/OrganizationMembershipListRequest.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ZendeskApi.Client.Requests
+{
+    public class OrganizationMembershipListRequest<T>
+    {
+        public OrganizationMembershipListRequest(IEnumerable<T> items)
+        {
+            Items = items;
+        }
+
+        [JsonProperty("organization_memberships")]
+        public IEnumerable<T> Items { get; set; }
+    }
+}

--- a/src/ZendeskApi.Client/Requests/Organization/OrganizationMembershipRequest.cs
+++ b/src/ZendeskApi.Client/Requests/Organization/OrganizationMembershipRequest.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace ZendeskApi.Client.Requests
+{
+    public class OrganizationMembershipRequest<T>
+    {
+        public OrganizationMembershipRequest(T organizationMembership)
+        {
+            OrganizationMembership = organizationMembership;
+        }
+
+        [JsonProperty("organization_membership")]
+        public T OrganizationMembership { get; set; }
+    }
+}

--- a/src/ZendeskApi.Client/Resources/Interfaces/Organization/IOrganizationMembershipsResource.cs
+++ b/src/ZendeskApi.Client/Resources/Interfaces/Organization/IOrganizationMembershipsResource.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ZendeskApi.Client.Models;
+using ZendeskApi.Client.Requests;
 using ZendeskApi.Client.Responses;
 
 namespace ZendeskApi.Client.Resources
@@ -54,6 +55,10 @@ namespace ZendeskApi.Client.Resources
             OrganizationMembership organizationMembership,
             CancellationToken cancellationToken = default(CancellationToken));
 
+        Task<OrganizationMembership> CreateAsync(
+            OrganizationMembershipCreateRequest organizationMembership,
+            CancellationToken cancellationToken = default(CancellationToken));
+
         [Obsolete("Use `PostByUserIdAsync` instead.")]
         Task<OrganizationMembership> PostForUserAsync(
             OrganizationMembership organizationMembership, 
@@ -65,8 +70,17 @@ namespace ZendeskApi.Client.Resources
             long userId,
             CancellationToken cancellationToken = default(CancellationToken));
 
+        Task<OrganizationMembership> PostByUserIdAsync(
+            OrganizationMembershipCreateRequest organizationMembership,
+            long userId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
         Task<JobStatusResponse> CreateAsync(
             IEnumerable<OrganizationMembership> organizationMemberships,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<JobStatusResponse> CreateAsync(
+            IEnumerable<OrganizationMembershipCreateRequest> organizationMemberships,
             CancellationToken cancellationToken = default(CancellationToken));
 
         Task<IPagination<OrganizationMembership>> MakeDefault(

--- a/src/ZendeskApi.Client/Resources/Organization/OrganizationMembershipsResource.cs
+++ b/src/ZendeskApi.Client/Resources/Organization/OrganizationMembershipsResource.cs
@@ -137,9 +137,18 @@ namespace ZendeskApi.Client.Resources
             OrganizationMembership organizationMembership,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = await CreateAsync<OrganizationMembershipResponse, OrganizationMembershipCreateRequest>(
-                ResourceUri,
+            return await CreateAsync(
                 new OrganizationMembershipCreateRequest(organizationMembership),
+                cancellationToken);
+        }
+
+        public async Task<OrganizationMembership> CreateAsync(
+            OrganizationMembershipCreateRequest organizationMembership,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response = await CreateAsync<OrganizationMembershipResponse, OrganizationMembershipRequest<OrganizationMembershipCreateRequest>>(
+                ResourceUri,
+                new OrganizationMembershipRequest<OrganizationMembershipCreateRequest>(organizationMembership),
                 "create-membership",
                 cancellationToken: cancellationToken
             );
@@ -165,9 +174,20 @@ namespace ZendeskApi.Client.Resources
             long userId,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = await CreateAsync<OrganizationMembershipResponse, OrganizationMembershipCreateRequest>(
-                string.Format(UsersUrlFormat, userId),
+            return await PostByUserIdAsync(
                 new OrganizationMembershipCreateRequest(organizationMembership),
+                userId,
+                cancellationToken);
+        }
+
+        public async Task<OrganizationMembership> PostByUserIdAsync(
+            OrganizationMembershipCreateRequest organizationMembership,
+            long userId,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response = await CreateAsync<OrganizationMembershipResponse, OrganizationMembershipRequest<OrganizationMembershipCreateRequest>>(
+                string.Format(UsersUrlFormat, userId),
+                new OrganizationMembershipRequest<OrganizationMembershipCreateRequest>(organizationMembership),
                 "create-membership",
                 scope: $"PostByUserIdAsync({userId})",
                 cancellationToken: cancellationToken
@@ -181,9 +201,18 @@ namespace ZendeskApi.Client.Resources
             IEnumerable<OrganizationMembership> organizationMemberships,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await CreateAsync<JobStatusResponse, OrganizationMembershipsRequest>(
+            return await CreateAsync(
+                organizationMemberships.Select(x => new OrganizationMembershipCreateRequest(x)),
+                cancellationToken);
+        }
+
+        public async Task<JobStatusResponse> CreateAsync(
+            IEnumerable<OrganizationMembershipCreateRequest> organizationMemberships,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await CreateAsync<JobStatusResponse, OrganizationMembershipListRequest<OrganizationMembershipCreateRequest>>(
                 $"{ResourceUri}/create_many",
-                new OrganizationMembershipsRequest { Item = organizationMemberships },
+                new OrganizationMembershipListRequest<OrganizationMembershipCreateRequest>(organizationMemberships),
                 "create-many-memberships",
                 HttpStatusCode.OK,
                 "PostAsync",

--- a/test/ZendeskApi.Client.IntegrationTests/Resources/OrganizationMembershipsResourceTests.cs
+++ b/test/ZendeskApi.Client.IntegrationTests/Resources/OrganizationMembershipsResourceTests.cs
@@ -65,7 +65,7 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
 
             var membership = await client
                 .OrganizationMemberships
-                .GetAsync(setup.OrganizationMembership.Id.Value);
+                .GetAsync(setup.OrganizationMembership.Id);
 
             Assert.NotNull(membership);
 
@@ -93,7 +93,7 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
 
             var membership = await client
                 .OrganizationMemberships
-                .GetForUserAndOrganizationAsync(setup.User.Id, setup.OrganizationMembership.Id.Value);
+                .GetForUserAndOrganizationAsync(setup.User.Id, setup.OrganizationMembership.Id);
 
             Assert.NotNull(membership);
 
@@ -143,17 +143,15 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
                     UserId = setup.User.Id
                 });
 
-            Assert.True(createdOrganisationMembership.Id.HasValue);
-
             var getOrganisationMembership = await client
                 .OrganizationMemberships
-                .GetAsync(createdOrganisationMembership.Id.Value);
+                .GetAsync(createdOrganisationMembership.Id);
 
             Assert.NotNull(getOrganisationMembership);
 
             await client
                 .OrganizationMemberships
-                .DeleteAsync(createdOrganisationMembership.Id.Value);
+                .DeleteAsync(createdOrganisationMembership.Id);
 
             await Teardown(client, setup);
         }
@@ -173,17 +171,15 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
                     UserId = setup.User.Id
                 }, setup.User.Id);
 
-            Assert.True(createdOrganisationMembership.Id.HasValue);
-
             var getOrganisationMembership = await client
                 .OrganizationMemberships
-                .GetAsync(createdOrganisationMembership.Id.Value);
+                .GetAsync(createdOrganisationMembership.Id);
 
             Assert.NotNull(getOrganisationMembership);
 
             await client
                 .OrganizationMemberships
-                .DeleteAsync(createdOrganisationMembership.Id.Value);
+                .DeleteAsync(createdOrganisationMembership.Id);
 
             await Teardown(client, setup);
         }
@@ -224,7 +220,7 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
 
             try
             {
-                foreach (var membership in membershipOne.Concat(membershipTwo).Where(x => x.Id.HasValue).Select(x => x.Id.Value))
+                foreach (var membership in membershipOne.Concat(membershipTwo).Select(x => x.Id))
                 {
                     await client
                         .OrganizationMemberships
@@ -247,11 +243,11 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
 
             await client
                 .OrganizationMemberships
-                .DeleteAsync(setup.OrganizationMembership.Id.Value);
+                .DeleteAsync(setup.OrganizationMembership.Id);
 
             var getOrganisationMembershipAfterDelete = await client
                 .OrganizationMemberships
-                .GetAsync(setup.OrganizationMembership.Id.Value);
+                .GetAsync(setup.OrganizationMembership.Id);
 
             Assert.Null(getOrganisationMembershipAfterDelete);
 
@@ -277,11 +273,11 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
 
             await client
                 .OrganizationMemberships
-                .DeleteAsync(setup.User.Id, setup.OrganizationMembership.Id.Value);
+                .DeleteAsync(setup.User.Id, setup.OrganizationMembership.Id);
 
             var getOrganisationMembershipAfterDelete = await client
                 .OrganizationMemberships
-                .GetAsync(setup.OrganizationMembership.Id.Value);
+                .GetAsync(setup.OrganizationMembership.Id);
 
             Assert.Null(getOrganisationMembershipAfterDelete);
 
@@ -329,11 +325,9 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
                     UserId = setup.User.Id
                 });
 
-            Assert.True(createdOrganisationMembership.Id.HasValue);
-
             var getOrganisationMembership = await client
                 .OrganizationMemberships
-                .GetAsync(createdOrganisationMembership.Id.Value);
+                .GetAsync(createdOrganisationMembership.Id);
 
             Assert.NotNull(getOrganisationMembership);
 
@@ -347,7 +341,7 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
         {
             await client
                 .OrganizationMemberships
-                .DeleteAsync(setup.OrganizationMembership.Id.Value);
+                .DeleteAsync(setup.OrganizationMembership.Id);
 
             await Teardown(client, setup);
         }

--- a/test/ZendeskApi.Client.IntegrationTests/Resources/OrganizationResourceTests.cs
+++ b/test/ZendeskApi.Client.IntegrationTests/Resources/OrganizationResourceTests.cs
@@ -142,7 +142,7 @@ namespace ZendeskApi.Client.IntegrationTests.Resources
 
             await client
                 .OrganizationMemberships
-                .DeleteAsync(organisationMembership.Id.Value);
+                .DeleteAsync(organisationMembership.Id);
 
             await client
                 .Users

--- a/test/ZendeskApi.Client.Tests/Resources/OrganizationMembershipsResourceTests.cs
+++ b/test/ZendeskApi.Client.Tests/Resources/OrganizationMembershipsResourceTests.cs
@@ -292,7 +292,9 @@ namespace ZendeskApi.Client.Tests.Resources
         {
             await Assert.ThrowsAsync<ZendeskRequestException>(async () => await _resource.CreateAsync(new OrganizationMembership
             {
-               Id = int.MinValue
+               Id = int.MinValue,
+               UserId = int.MinValue,
+               OrganizationId = int.MinValue
             }));
         }
 
@@ -316,7 +318,9 @@ namespace ZendeskApi.Client.Tests.Resources
         {
             await Assert.ThrowsAsync<ZendeskRequestException>(async () => await _resource.PostForUserAsync(new OrganizationMembership
             {
-                Id = int.MinValue
+                Id = int.MinValue,
+                UserId = int.MinValue,
+                OrganizationId = int.MinValue
             }, 102));
         }
 
@@ -340,7 +344,9 @@ namespace ZendeskApi.Client.Tests.Resources
         {
             await Assert.ThrowsAsync<ZendeskRequestException>(async () => await _resource.PostByUserIdAsync(new OrganizationMembership
             {
-                Id = int.MinValue
+                Id = int.MinValue,
+                UserId = int.MinValue,
+                OrganizationId = int.MinValue
             }, 102));
         }
 
@@ -373,7 +379,9 @@ namespace ZendeskApi.Client.Tests.Resources
             {
                 new OrganizationMembership
                 {
-                    Id = int.MinValue
+                    Id = int.MinValue,
+                    UserId = int.MinValue,
+                    OrganizationId = int.MinValue
                 }
             }));
         }

--- a/test/ZendeskApi.Client.Tests/ResourcesSampleSites/OrganizationMembershipsResourceSampleSite.cs
+++ b/test/ZendeskApi.Client.Tests/ResourcesSampleSites/OrganizationMembershipsResourceSampleSite.cs
@@ -122,15 +122,20 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     })
                     .MapPost("api/v2/organization_memberships", (req, resp, routeData) =>
                     {
-                        var request = req.Body.ReadAs<OrganizationMembershipCreateRequest>();
+                        var request = req.Body.ReadAs<OrganizationMembershipRequest<OrganizationMembershipCreateRequest>>();
                         var membership = request.OrganizationMembership;
 
-                        return RequestHelper.Create<OrganizationMembershipResponse, OrganizationMembership>(
+                        return RequestHelper.CreateModel<OrganizationMembershipResponse, OrganizationMembershipCreateRequest, OrganizationMembership>(
                             req,
                             resp,
                             routeData,
-                            item => item.Id,
+                            item => item.UserId,
                             membership,
+                            (model, createRequest) =>
+                            {
+                                model.UserId = createRequest.UserId;
+                                model.OrganizationId = createRequest.OrganizationId;
+                            },
                             item => new OrganizationMembershipResponse
                             {
                                 OrganizationMembership = item
@@ -138,15 +143,20 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     })
                     .MapPost("api/v2/users/{userId}/organization_memberships", (req, resp, routeData) =>
                     {
-                        var request = req.Body.ReadAs<OrganizationMembershipCreateRequest>();
+                        var request = req.Body.ReadAs<OrganizationMembershipRequest<OrganizationMembershipCreateRequest>>();
                         var membership = request.OrganizationMembership;
 
-                        return RequestHelper.Create<OrganizationMembershipResponse, OrganizationMembership>(
+                        return RequestHelper.CreateModel<OrganizationMembershipResponse, OrganizationMembershipCreateRequest, OrganizationMembership>(
                             req,
                             resp,
                             routeData,
-                            item => item.Id,
+                            item => item.UserId,
                             membership,
+                            (model, createRequest) =>
+                            {
+                                model.UserId = createRequest.UserId;
+                                model.OrganizationId = createRequest.OrganizationId;
+                            },
                             item => new OrganizationMembershipResponse
                             {
                                 OrganizationMembership = item
@@ -154,15 +164,20 @@ namespace ZendeskApi.Client.Tests.ResourcesSampleSites
                     })
                     .MapPost("api/v2/organization_memberships/create_many", (req, resp, routeData) =>
                     {
-                        var request = req.Body.ReadAs<OrganizationMembershipsRequest>();
-                        var memberships = request.Item;
+                        var request = req.Body.ReadAs<OrganizationMembershipListRequest<OrganizationMembershipCreateRequest>>();
+                        var memberships = request.Items;
 
-                        return RequestHelper.CreateMany<JobStatusResponse, OrganizationMembership>(
+                        return RequestHelper.CreateManyModel<JobStatusResponse, OrganizationMembershipCreateRequest, OrganizationMembership>(
                             req,
                             resp,
                             routeData,
-                            item => item.Id,
+                            item => item.UserId,
                             memberships,
+                            (model, createRequest) =>
+                            {
+                                model.UserId = createRequest.UserId;
+                                model.OrganizationId = createRequest.OrganizationId;
+                            },
                             items => new JobStatusResponse
                             {
                                 Total = items.Count()


### PR DESCRIPTION
This is what I was thinking re: https://github.com/justeat/ZendeskApiClient/issues/78 you can see that our model for Organization Memberships is just wrong according to: https://developer.zendesk.com/rest_api/docs/support/organization_memberships#json-format UserId & OrganizationId are mandatory so should not be nullable. Id is only non mandatory on creation...

This would make things more explicit with creates using a specific model. Allowing the consumer to create that model via the full-fat model if that's their cup of tea.

We already take this type of approach for creating tickets (https://github.com/justeat/ZendeskApiClient/blob/master/src/ZendeskApi.Client/Resources/Ticket/TicketsResource.cs#L203) so it would be moving more in that direction. Although will introduce breaking changes with the full-fat model changes.

I've tried to support existing operations by leaving the methods for creating using the full-fat model and just mapping to the specific model method.

I guess we need to decide if we want to go in this direction and just break things, but for the better as it will remove un-required null checks for consumers. Whether we want to go full-fat models but leave confusion/ambiguity when some things are updated and others are not.