### PR TITLE
Ensure artifact is generated during "dotnet pack" command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ clone_depth: 1
 test_script:
 - dotnet test -c Release .\test\ZendeskApi.Client.Tests\ZendeskApi.Client.Tests.csproj
 after_build:
-- dotnet pack .\src\ZendeskApi.Client\ZendeskApi.Client.csproj -o ../../output --no-build
+- dotnet pack .\src\ZendeskApi.Client\ZendeskApi.Client.csproj -o ./output --no-build
 artifacts:
 - path: 'output\*.nupkg'
 deploy:


### PR DESCRIPTION
recently upgraded image from VS 2015 -> VS 2019

`dotnet pack` on VS 2015 image:
```
dotnet pack .\src\ZendeskApi.Client\ZendeskApi.Client.csproj -o ../../output --no-build
  Successfully created package 'C:\projects\zendeskapiclient\output\ZendeskApi.Client.4.0.1-alpha-701.nupkg'.
```

`dotnet pack` on VS 2019 image:
```
dotnet pack .\src\ZendeskApi.Client\ZendeskApi.Client.csproj -o ../../output --no-build
  Successfully created package 'C:\output\ZendeskApi.Client.5.0.0-alpha-732.nupkg'
```

You can see from above that the `\projects\zendeskapiclient\` is missing and I think the new version of MS Build is using a different location to execute the commands

PR fixes this. Sample output from this PR:

```
dotnet pack .\src\ZendeskApi.Client\ZendeskApi.Client.csproj -o ./output --no-build
  Successfully created package 'C:\projects\zendeskapiclient\output\ZendeskApi.Client.5.0.0-alpha-734.nupkg'.
```