### PR TITLE
Upgrade target framework to dotnet6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A .netstandard NuGet package for use with the  Zendesk v2 API.
 
 # Breaking Changes
 
+## 6.x.x
+#### Added support for .NET 6
+
+ZendeskApiClient now targets both .NET Standard 2.0 and .NET 6, enabling users to leverage the latest runtime features and performance optimizations for their projects. Please note that with this update, support for .NET Core 3.1 is no longer targeted.
+
 ## 4.x.x
 This will allow for cursor pagination on some endpoints. We have kept the original offset pagination available so that this release is backward compatible, however due to Zendesk adding a variation of cursor pagination to this single [endpoint](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_audits/#pagination), we have modified the original `cursorPager` class to now be `cursorPagerVariant`. If you use the TicketAudits endpoint please update your code.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Zendesk Api Client
 [![NuGet Version](https://img.shields.io/nuget/vpre/ZendeskApi.Client.svg?style=flat-square)](https://www.nuget.org/packages/ZendeskApi.Client)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/ZendeskApi.Client.svg?style=flat-square)](https://www.nuget.org/packages/ZendeskApi.Client)
+[![ci](https://github.com/justeat/ZendeskApiClient/actions/workflows/ci.yml/badge.svg)](https://github.com/justeat/ZendeskApiClient/actions/workflows/ci.yml)
 
 A .netstandard NuGet package for use with the  Zendesk v2 API.
 

--- a/src/ZendeskApi.Client/ZendeskApi.Client.csproj
+++ b/src/ZendeskApi.Client/ZendeskApi.Client.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\ZendeskApi.Build\ZendeskApi.Commons.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>A Zendesk Api Client for use with the ZendeskApi v2</Description>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/test/ZendeskApi.Client.IntegrationTests/ZendeskApi.Client.IntegrationTests.csproj
+++ b/test/ZendeskApi.Client.IntegrationTests/ZendeskApi.Client.IntegrationTests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
+++ b/test/ZendeskApi.Client.Tests/ZendeskApi.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>ZendeskApi.Client.Tests</AssemblyName>
     <PackageId>ZendeskApi.Client.Tests</PackageId>
@@ -17,16 +17,16 @@
       <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AutoMapper" Version="6.1.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.32" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.20" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.2.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
# Version 6.0.0 of ZendeskApiClient

This PR includes:

* upgrading target framework to dotnet6 (pain-free experience)
* adding release notes
* [aside] adding status badge for the `ci` workflow

