### PR TITLE
[RED-2026] Set a default user agent so Zendesk can identify the requests

### DIFF
--- a/src/ZendeskApi.Build/ZendeskApi.Commons.props
+++ b/src/ZendeskApi.Build/ZendeskApi.Commons.props
@@ -23,7 +23,7 @@
   <PropertyGroup>
       <Major>7</Major>
       <Minor>0</Minor>
-      <Revision>5</Revision>
+      <Revision>6</Revision>
       <PackageVersion>$(Major).$(Minor).$(Revision)</PackageVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ZendeskApi.Client/ZendeskApiClient.cs
+++ b/src/ZendeskApi.Client/ZendeskApiClient.cs
@@ -52,6 +52,7 @@ namespace ZendeskApi.Client
             var authorizationHeader = _options.GetAuthorizationHeader();
 
             client.DefaultRequestHeaders.Add("Authorization", authorizationHeader);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("justeat.zendesk-api-client-csharp");
 
             client.DefaultRequestHeaders
               .Accept
@@ -73,7 +74,7 @@ namespace ZendeskApi.Client
             {
                 BaseAddress = new Uri("https://status.zendesk.com")
             };
-
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("justeat.zendesk-api-client-csharp");
             client.DefaultRequestHeaders
                 .Accept
                 .Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/ZendeskApi.Client/ZendeskApiClientFactory.cs
+++ b/src/ZendeskApi.Client/ZendeskApiClientFactory.cs
@@ -38,8 +38,9 @@ namespace ZendeskApi.Client
 
             client.DefaultRequestHeaders
                 .Add(
-                    "Authorization", 
+                    "Authorization",
                     authorizationHeader);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("justeat.zendesk-api-client-csharp");
 
             client.DefaultRequestHeaders
                 .Accept
@@ -57,7 +58,7 @@ namespace ZendeskApi.Client
                 .CreateClient();
 
             client.BaseAddress = new Uri("https://status.zendesk.com");
-
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("justeat.zendesk-api-client-csharp");
             client.DefaultRequestHeaders
                 .Accept
                 .Add(new MediaTypeWithQualityHeaderValue("application/json"));


### PR DESCRIPTION
### Description

Sets a default user agent. 
We can now see it in our logs the requests are coming from this SDK . 

<img width="493" alt="Screenshot 2023-11-14 at 3 21 44 pm" src="https://github.com/justeat/ZendeskApiClient/assets/309246/f4990a86-c4dd-4ac5-89bf-b8382ce4fb77">


@mikerogers123 are you happy with this user agent string? 